### PR TITLE
GH_ISSUE_42: right-size Nomad job resource requests (~5.5 GHz CPU + ~21 GiB mem freed)

### DIFF
--- a/nomad/jobs/games/phlebotomy-game/phlebotomy-game.hcl
+++ b/nomad/jobs/games/phlebotomy-game/phlebotomy-game.hcl
@@ -16,6 +16,8 @@ image        = "registry.munchbox.cc/phlebotomy-game:latest"
 port         = 8080
 host_network = false
 size         = "tiny"
+cpu          = 50
+memory       = 32
 storage      = "ephemeral"
 
 # --- Traefik integration ---

--- a/nomad/jobs/infrastructure/coredns/coredns.nomad.hcl
+++ b/nomad/jobs/infrastructure/coredns/coredns.nomad.hcl
@@ -193,8 +193,11 @@ EOH
       }
 
       # --- Resources ---
+      # CPU bumped from 100 to 300 MHz: 7d p95 was 179 MHz with bursts to
+      # 2.2 GHz under DNS load (system job, runs everywhere — small per-node
+      # increase but matters for query latency under load).
       resources {
-        cpu    = 100
+        cpu    = 300
         memory = 64
       }
 

--- a/nomad/jobs/infrastructure/g3-proxy/g3-proxy.nomad.hcl
+++ b/nomad/jobs/infrastructure/g3-proxy/g3-proxy.nomad.hcl
@@ -185,8 +185,8 @@ EOH
 
       # --- Resources ---
       resources {
-        cpu        = 1024
-        memory     = 1024
+        cpu        = 150
+        memory     = 96
         memory_max = 1536
       }
 

--- a/nomad/jobs/infrastructure/github-runner-moat-vm/github-runner-moat-vm.nomad.hcl
+++ b/nomad/jobs/infrastructure/github-runner-moat-vm/github-runner-moat-vm.nomad.hcl
@@ -157,7 +157,7 @@ EOF
 
       resources {
         cpu    = 6000
-        memory = 8192
+        memory = 4512
       }
 
       kill_timeout = "120s"

--- a/nomad/jobs/infrastructure/github-runner-moat/github-runner-moat.nomad.hcl
+++ b/nomad/jobs/infrastructure/github-runner-moat/github-runner-moat.nomad.hcl
@@ -157,7 +157,7 @@ EOF
 
       resources {
         cpu    = 6000
-        memory = 4096
+        memory = 2176
       }
 
       kill_timeout = "120s"

--- a/nomad/jobs/infrastructure/haproxy/haproxy.nomad.hcl
+++ b/nomad/jobs/infrastructure/haproxy/haproxy.nomad.hcl
@@ -319,7 +319,7 @@ backend redis_backend
 
       # --- Resources ---
       resources {
-        cpu    = 100
+        cpu    = 200
         memory = 64
       }
 

--- a/nomad/jobs/infrastructure/keepalived/keepalived.nomad.hcl
+++ b/nomad/jobs/infrastructure/keepalived/keepalived.nomad.hcl
@@ -220,7 +220,7 @@ wg show wg0 latest-handshakes 2>/dev/null \
       }
 
       resources {
-        cpu    = 50
+        cpu    = 150
         memory = 64
       }
 

--- a/nomad/jobs/infrastructure/oauth2-proxy/oauth2-proxy.nomad.hcl
+++ b/nomad/jobs/infrastructure/oauth2-proxy/oauth2-proxy.nomad.hcl
@@ -181,8 +181,8 @@ EOF
 
       # --- Resources ---
       resources {
-        cpu    = 100
-        memory = 64
+        cpu    = 50
+        memory = 32
       }
 
       # --- Termination ---

--- a/nomad/jobs/infrastructure/oracle-watchdog/oracle-watchdog.nomad.hcl
+++ b/nomad/jobs/infrastructure/oracle-watchdog/oracle-watchdog.nomad.hcl
@@ -250,7 +250,7 @@ CLOUDFLARE_API_TOKEN={{ .Data.data.api_token }}
 
       # --- Resources ---
       resources {
-        cpu    = 100
+        cpu    = 50
         memory = 64
       }
 

--- a/nomad/jobs/infrastructure/patroni/patroni.nomad.hcl
+++ b/nomad/jobs/infrastructure/patroni/patroni.nomad.hcl
@@ -701,7 +701,7 @@ PG_EXPORTER_DISABLE_SETTINGS_METRICS=false
       }
 
       resources {
-        cpu    = 50
+        cpu    = 250
         memory = 64
       }
     }

--- a/nomad/jobs/infrastructure/redis-sentinel/redis-sentinel.nomad.hcl
+++ b/nomad/jobs/infrastructure/redis-sentinel/redis-sentinel.nomad.hcl
@@ -447,7 +447,7 @@ REDIS_EXPORTER_INCL_SYSTEM_METRICS=true
       }
 
       resources {
-        cpu    = 50
+        cpu    = 200
         memory = 64
       }
     }

--- a/nomad/jobs/infrastructure/theme-server/theme-server.hcl
+++ b/nomad/jobs/infrastructure/theme-server/theme-server.hcl
@@ -16,6 +16,8 @@ port         = 8078
 static_port  = 8078
 host_network = true
 size         = "tiny"
+cpu          = 50
+memory       = 32
 
 # --- Run on large Oracle Cloud nodes ---
 constraints = [

--- a/nomad/jobs/infrastructure/traefik/traefik.nomad.hcl
+++ b/nomad/jobs/infrastructure/traefik/traefik.nomad.hcl
@@ -858,8 +858,8 @@ EOH
       }
 
       resources {
-        cpu    = 200
-        memory = 256
+        cpu    = 150
+        memory = 64
       }
     }
 

--- a/nomad/jobs/infrastructure/trivy-server/trivy-server.nomad.hcl
+++ b/nomad/jobs/infrastructure/trivy-server/trivy-server.nomad.hcl
@@ -30,8 +30,16 @@ job "trivy-server" {
   }
 
   # ---------------------------------------------------------------------------
-  # Placement
+  # Placement — home cluster only (Oracle has unreliable image pulls and the
+  # vuln DB sync is bandwidth-heavy; previously fit only on home nodes by
+  # accident of resource size, now needs an explicit exclusion).
   # ---------------------------------------------------------------------------
+
+  constraint {
+    attribute = "${meta.cloud}"
+    operator  = "!="
+    value     = "oracle"
+  }
 
   # ---------------------------------------------------------------------------
   # Task Group: server
@@ -111,8 +119,10 @@ job "trivy-server" {
         env         = true
       }
 
+      # Vuln DB sync spikes well above steady-state (OOM-killed at 256).
+      # Keeping memory at the historical 512 MiB; CPU was safely cut.
       resources {
-        cpu    = 500
+        cpu    = 100
         memory = 512
       }
 

--- a/nomad/jobs/media/deluge/deluge.nomad.hcl
+++ b/nomad/jobs/media/deluge/deluge.nomad.hcl
@@ -200,7 +200,7 @@ EOF
 
       resources {
         cpu    = 200
-        memory = 512
+        memory = 192
       }
     }
 
@@ -276,7 +276,7 @@ EOF
 
       resources {
         cpu    = 1500
-        memory = 1024
+        memory = 192
       }
 
       kill_timeout = "30s"

--- a/nomad/jobs/media/radarr/radarr.hcl
+++ b/nomad/jobs/media/radarr/radarr.hcl
@@ -17,6 +17,7 @@ constraints = [
   { attribute = "$${meta.gpu}", operator = "=", value = "true" }
 ]
 size         = "medium"
+memory       = 160
 
 # --- Health check (use /ping to avoid auth failures in logs) ---
 health_path  = "/ping"

--- a/nomad/jobs/media/readarr/readarr.hcl
+++ b/nomad/jobs/media/readarr/readarr.hcl
@@ -18,6 +18,7 @@ constraints = [
   { attribute = "$${meta.gpu}", operator = "=", value = "true" }
 ]
 size         = "medium"
+memory       = 192
 
 # --- Health check (use /ping to avoid auth failures in logs) ---
 health_path  = "/ping"

--- a/nomad/jobs/monitoring/alertmanager/alertmanager.hcl
+++ b/nomad/jobs/monitoring/alertmanager/alertmanager.hcl
@@ -12,7 +12,9 @@
 name  = "alertmanager"
 image = "prom/alertmanager:v0.29.0"
 port  = 9093
-size  = "tiny"
+size   = "tiny"
+cpu    = 50
+memory = 64
 host_network = true
 vault = true
 

--- a/nomad/jobs/monitoring/blackbox-exporter/blackbox-exporter.hcl
+++ b/nomad/jobs/monitoring/blackbox-exporter/blackbox-exporter.hcl
@@ -15,6 +15,7 @@ port         = 9115
 static_port  = 9115
 host_network = true
 size         = "tiny"
+memory       = 64
 vault        = true
 
 # --- Traefik routing ---
@@ -42,5 +43,12 @@ templates = [
 # --- Service tags ---
 tags = ["monitoring", "blackbox-exporter", "probes"]
 
-# --- Placement ---
+# --- Placement: home cluster only ---
+# Probes are scraped by prometheus and represent the cluster's view of
+# external/internal endpoints. Running blackbox on Oracle adds tunnel
+# latency to every probe and exposes it to oracle-node-2's known
+# reliability churn (alloc went `lost` before this constraint).
 node = "any"
+constraints = [
+  { attribute = "$${meta.cloud}", operator = "!=", value = "oracle" }
+]

--- a/nomad/jobs/monitoring/trivy-dashboard/trivy-dashboard.nomad.hcl
+++ b/nomad/jobs/monitoring/trivy-dashboard/trivy-dashboard.nomad.hcl
@@ -37,6 +37,15 @@ job "trivy-dashboard" {
     value     = "amd64"
   }
 
+  # Home cluster only — Oracle amd64 nodes can match the arch above but
+  # don't have a working path to the home registry / consul / vault that
+  # this dashboard needs.
+  constraint {
+    attribute = "${meta.cloud}"
+    operator  = "!="
+    value     = "oracle"
+  }
+
 
   # ---------------------------------------------------------------------------
   # Task Group: dashboard
@@ -140,8 +149,8 @@ job "trivy-dashboard" {
       }
 
       resources {
-        cpu    = 100
-        memory = 128
+        cpu    = 50
+        memory = 64
       }
 
       kill_timeout = "10s"

--- a/nomad/jobs/temporal-workflows/backup-worker/backup-worker.nomad.hcl
+++ b/nomad/jobs/temporal-workflows/backup-worker/backup-worker.nomad.hcl
@@ -154,10 +154,13 @@ job "backup-worker" {
       }
 
       # --- Resources ---
-      # Registry backup tars ~600MB of data; needs memory for gzip
+      # Registry backup tars ~600MB of data; needs memory headroom for gzip
+      # bursts. Steady-state usage is ~30 MiB, so request stays small and
+      # memory_max permits the burst when a registry backup runs.
       resources {
-        cpu    = 2000
-        memory = 512
+        cpu        = 2000
+        memory     = 96
+        memory_max = 768
       }
 
       kill_timeout = "30s"

--- a/nomad/jobs/temporal-workflows/cleanup-worker/cleanup-worker.nomad.hcl
+++ b/nomad/jobs/temporal-workflows/cleanup-worker/cleanup-worker.nomad.hcl
@@ -180,8 +180,8 @@ job "cleanup-worker" {
       }
 
       resources {
-        cpu    = 200
-        memory = 128
+        cpu    = 100
+        memory = 32
       }
 
       kill_timeout = "30s"

--- a/nomad/jobs/web/cloudflare-log-collector-webpage/cloudflare-log-collector-webpage.hcl
+++ b/nomad/jobs/web/cloudflare-log-collector-webpage/cloudflare-log-collector-webpage.hcl
@@ -14,8 +14,10 @@ image = "registry.munchbox.cc/cloudflare-log-collector-web:v0.1.15"
 port  = 80
 node  = "any"
 host_network = false
-size  = "tiny"
-count = 3
+size   = "tiny"
+cpu    = 50
+memory = 32
+count  = 3
 storage = "ephemeral"
 
 # --- Placement: one instance per node ---

--- a/nomad/jobs/web/dashboard/dashboard.hcl
+++ b/nomad/jobs/web/dashboard/dashboard.hcl
@@ -16,7 +16,16 @@ port         = 80
 host_network = false
 node         = "any"
 size         = "tiny"
+cpu          = 50
+memory       = 32
 storage      = "ephemeral"
+
+# --- Placement: home cluster only (TODO: see issue tracking why
+# CF-tunnel + oauth2-proxy auth flow breaks when this lands behind WG
+# on an Oracle node — single curl works, browser auth flow returns 502)
+constraints = [
+  { attribute = "$${meta.cloud}", operator = "!=", value = "oracle" }
+]
 
 # --- Traefik integration ---
 traefik      = true

--- a/nomad/jobs/web/g3-webpage/g3-webpage.hcl
+++ b/nomad/jobs/web/g3-webpage/g3-webpage.hcl
@@ -14,8 +14,10 @@ image = "registry.munchbox.cc/g3-web:v0.5.1"
 port  = 80
 node  = "any"
 host_network = false
-size  = "tiny"
-count = 3
+size   = "tiny"
+cpu    = 50
+memory = 32
+count  = 3
 storage = "ephemeral"
 
 # --- Placement: one instance per node ---

--- a/nomad/jobs/web/health-checker/health-checker.hcl
+++ b/nomad/jobs/web/health-checker/health-checker.hcl
@@ -14,7 +14,8 @@ image = "registry.munchbox.cc/health-checker:latest"
 port  = 8080
 node  = "any"
 host_network = true
-size = "small"
+size   = "small"
+memory = 32
 storage = "ephemeral"
 
 # --- Volume mounts ---

--- a/nomad/jobs/web/nginx-resume/nginx-resume.hcl
+++ b/nomad/jobs/web/nginx-resume/nginx-resume.hcl
@@ -14,8 +14,10 @@ image = "registry.munchbox.cc/alex-resume:v0.0.1"
 port  = 80
 node  = "any"
 host_network = false
-size  = "tiny"
-count = 3
+size   = "tiny"
+cpu    = 50
+memory = 32
+count  = 3
 storage = "ephemeral"
 
 # --- Placement: one instance per node ---

--- a/nomad/jobs/web/nomad-temporal-jobs-webpage/nomad-temporal-jobs-webpage.hcl
+++ b/nomad/jobs/web/nomad-temporal-jobs-webpage/nomad-temporal-jobs-webpage.hcl
@@ -14,8 +14,10 @@ image = "registry.munchbox.cc/temporal-workers-web:v0.2.2"
 port  = 80
 node  = "any"
 host_network = false
-size  = "tiny"
-count = 3
+size   = "tiny"
+cpu    = 50
+memory = 32
+count  = 3
 storage = "ephemeral"
 
 # --- Placement: one instance per node, avoid oracle nodes ---

--- a/nomad/jobs/web/oracle-watchdog-webpage/oracle-watchdog-webpage.hcl
+++ b/nomad/jobs/web/oracle-watchdog-webpage/oracle-watchdog-webpage.hcl
@@ -14,8 +14,10 @@ image = "registry.munchbox.cc/oracle-watchdog-web:v1.3.0"
 port  = 80
 node  = "any"
 host_network = false
-size  = "tiny"
-count = 3
+size   = "tiny"
+cpu    = 50
+memory = 32
+count  = 3
 storage = "ephemeral"
 
 # --- Placement: one instance per node ---

--- a/nomad/jobs/web/personal-site/personal-site.hcl
+++ b/nomad/jobs/web/personal-site/personal-site.hcl
@@ -14,8 +14,10 @@ image = "registry.munchbox.cc/personal-site:v0.0.5"
 port  = 80
 node  = "any"
 host_network = false
-size  = "tiny"
-count = 3
+size   = "tiny"
+cpu    = 50
+memory = 32
+count  = 3
 storage = "ephemeral"
 
 # --- Placement: one instance per node ---

--- a/nomad/jobs/web/s3-orchestrator-webpage/s3-orchestrator-webpage.hcl
+++ b/nomad/jobs/web/s3-orchestrator-webpage/s3-orchestrator-webpage.hcl
@@ -14,8 +14,10 @@ image = "registry.munchbox.cc/s3-orchestrator-web:v0.46.45"
 port  = 80
 node  = "any"
 host_network = false
-size  = "tiny"
-count = 3
+size   = "tiny"
+cpu    = 50
+memory = 32
+count  = 3
 storage = "ephemeral"
 
 # --- Placement: one instance per node ---


### PR DESCRIPTION
Closes #42.

## Summary
Lowers over-provisioned CPU/memory across ~25 jobs and bumps a handful of under-provisioned exporters/data-plane jobs based on a 7-day Prometheus usage profile. Net cluster effect: **~5.5 GHz CPU and ~21 GiB memory freed**.

Most of the memory savings come from `github-runner-moat-vm` and the seven `count=3` Hugo webpages.

## What's in the commit
- **Down-sized** (memory only or CPU+memory): both github-runner-moat jobs, g3-proxy, trivy-server CPU only (memory kept at 512 — reverted after vuln-DB-sync OOM), backup-worker (memory_max for gzip bursts), cleanup-worker, trivy-dashboard, oracle-watchdog/agent, deluge/deluge, deluge/gluetun, radarr, readarr, health-checker, dashboard, phlebotomy-game, theme-server, blackbox-exporter, oauth2-proxy, alertmanager, traefik/traefik-log-dashboard, 7× Hugo webpages.
- **Bumped up** (under-provisioned): patroni/postgres-exporter, redis-sentinel/redis-exporter, coredns, keepalived, haproxy.
- pve-exporter under-provisioned bump deferred at user request.

## Methodology
- Queried `nomad_client_allocs_cpu_total_ticks` (MHz) and `nomad_client_allocs_memory_rss / 1Mi` over a 7-day window.
- Aggregated `max by (job, group, task)` across allocations, then `quantile_over_time(0.95, ...)` and `max_over_time(...)`.
- Over-provisioned threshold: p95 < 25% of request AND max < 50% of request. Suggested new request: `max(p95 * 1.5, max * 1.2)` rounded to 50 MHz / 32 MiB.
- STATEFUL/INFRA tasks and anything OOM-killed or CPU-throttled in the window were left alone.

## Side-effect fixes folded in
The smaller resource requests let several home-cluster-only jobs land on Oracle nodes for the first time, where they hit unrelated issues (Oracle WG flap, CF-tunnel + oauth2-proxy auth flow timing out behind WG). Added `meta.cloud != oracle` constraints to:
- `trivy-server`
- `trivy-dashboard`
- `blackbox-exporter`
- `dashboard`

The "why does the CF-tunnel + oauth2-proxy auth flow break for an Oracle-backed origin" question is left as a separate follow-up — single curl works (returns 401), browser auth flow returns CF 502.

## Test plan
- [x] Each affected job re-deployed one-at-a-time during the session.
- [x] Allocation health verified per-job; trivy-server reverted to 512 MiB after OOM at 96 then 256.
- [x] coredns full system-job alloc count (11/11) confirmed after restarting docker+nomad+consul on oracle-node-1 (which was wedged for unrelated reasons).
- [x] dashboard re-pinned to home cluster after CF 502 on Oracle-arm-1 backend.
- [ ] 24h health check post-merge — confirm no new OOM/restart events on the right-sized tasks.
- [ ] 1-week post-deploy: re-run the same Prometheus queries to verify nothing tripped (no new OOMs, no new throttling).

## Excluded from this PR
- Submodule drift (`src/oracle-watchdog`, `src/s3-orchestrator`) — unrelated to right-sizing, will need its own ticket if it should be bumped on main.
- pve-exporter CPU bump (skipped at user request).