### PR TITLE
GH_ISSUE_44: drop src/s3-orchestrator submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -10,9 +10,6 @@
 [submodule "infrastructure/providers/terraform-provider-pihole"]
 	path = infrastructure/providers/terraform-provider-pihole
 	url = https://github.com/ryanwholey/terraform-provider-pihole.git
-[submodule "src/s3-orchestrator"]
-	path = src/s3-orchestrator
-	url = https://github.com/afreidah/s3-orchestrator.git
 [submodule "src/cloudflare-log-collector"]
 	path = src/cloudflare-log-collector
 	url = https://github.com/afreidah/cloudflare-log-collector.git


### PR DESCRIPTION
Closes #44.

s3-orchestrator is its own self-contained project now. Munchbox consumes the published registry image, not the source — nothing in this repo references the submodule path. Removes the submodule entry from `.gitmodules` and the worktree pointer.