### PR TITLE
GH_ISSUE_46: add Vault audit-log rotation via Ansible

### DIFF
--- a/infrastructure/ansible/roles/vault/tasks/main.yml
+++ b/infrastructure/ansible/roles/vault/tasks/main.yml
@@ -188,3 +188,16 @@
     src: vault.sh.j2
     dest: /etc/profile.d/vault.sh
     mode: "0644"
+
+# -------------------------------------------------------------------------------
+# Log Rotation
+# -------------------------------------------------------------------------------
+
+- name: Deploy logrotate config for Vault audit log
+  template:
+    src: vault-logrotate.j2
+    dest: /etc/logrotate.d/vault
+    owner: root
+    group: root
+    mode: "0644"
+  tags: [logrotate, vault_logrotate]

--- a/infrastructure/ansible/roles/vault/templates/vault-logrotate.j2
+++ b/infrastructure/ansible/roles/vault/templates/vault-logrotate.j2
@@ -1,0 +1,23 @@
+# Managed by Ansible — roles/vault/tasks/main.yml
+# Rotation for the Vault file audit backend. Without this, audit.log grows
+# unbounded (already hit 7.5 GB on nomad-server-03 before this was codified).
+#
+# `size` triggers an out-of-cycle rotation when the file gets large between
+# daily runs — important to drain the existing oversize log on first apply.
+# `create` + the postrotate SIGHUP let Vault reopen the new file without
+# losing audit entries (Vault 1.7+ honors SIGHUP for the file backend).
+
+{{ vault_log_dir }}/audit.log {
+    daily
+    rotate 7
+    size 100M
+    maxsize 1G
+    compress
+    delaycompress
+    missingok
+    notifempty
+    create 0600 {{ vault_user }} {{ vault_group }}
+    postrotate
+        systemctl kill -s HUP {{ vault_service_name }} > /dev/null 2>&1 || true
+    endscript
+}


### PR DESCRIPTION
Closes #46.

## Summary
The Vault file audit backend writes to `/var/log/vault/audit.log` — a custom path that no stock logrotate config covers. The file had grown to **7.1 GB on nomad-server-03** (52% of root) and **3.2 GB on goren** before this landed.

Adds a `logrotate` fragment to the vault Ansible role: daily + size 100M / maxsize 1G triggers, compress with delaycompress, `postrotate` SIGHUPs Vault so it reopens the new file (Vault 1.7+ honors SIGHUP for the file audit backend).

Nomad and Consul daemons log to journald — `/var/log/{nomad,consul}/` were empty everywhere checked — so they don't need the same treatment.

## What deployed during work
- Config landed via `ansible-playbook playbooks/vault-setup.yml --tags logrotate` on goren / stabler / nomad-server-03.
- Forced one-shot `logrotate -f` to drain the existing oversize logs.
- Manually `gzip`'d the rotated `audit.log.1` files (delaycompress holds them uncompressed for one cycle).
- Result: **nomad-server-03 root went from 52% → 29%** (~7 GB recovered); goren went from 19% → 18% (~3 GB).

## Test plan
- [x] Config diff applied cleanly to all 3 vault hosts (goren, stabler, nomad-server-03).
- [x] Vault remained `active` on all hosts after SIGHUP.
- [x] stabler (current leader) is writing to the new `audit.log` post-rotation.
- [ ] Confirm tomorrow's automatic logrotate cycle compresses today's `audit.log.1` and rolls cleanly.