### PR TITLE
GH_ISSUE_48: post-#42 cleanup — backup-worker OOM/DNS, s3-orchestrator memory, submodule bump

### DIFF
--- a/nomad/jobs/infrastructure/s3-orchestrator/s3-orchestrator.nomad.hcl
+++ b/nomad/jobs/infrastructure/s3-orchestrator/s3-orchestrator.nomad.hcl
@@ -383,11 +383,10 @@ EOH
       }
 
       # --- Resources ---
-  		resources {
- 		    cpu        = 500
- 		    memory     = 512
- 		    memory_max = 1000
- 		  }
+      resources {
+        cpu    = 500
+        memory = 1024
+      }
 
       # --- Termination ---
       kill_timeout = "30s"

--- a/nomad/jobs/temporal-workflows/backup-worker/backup-worker.nomad.hcl
+++ b/nomad/jobs/temporal-workflows/backup-worker/backup-worker.nomad.hcl
@@ -46,6 +46,16 @@ job "backup-worker" {
     count = 1
 
     network {
+      # Use the host's local stub resolver so .consul lookups reach the
+      # Consul agent (via dnsmasq) instead of falling through to pi-hole,
+      # which lacks a .consul authority and lets search-domain expansion
+      # rewrite s3-orchestrator.service.consul -> .munchbox.cc and resolve
+      # to the wildcard goren IP (causing PutObject -> 192.168.68.60:9000
+      # connection-refused failures).
+      dns {
+        servers  = ["127.0.0.53"]
+        searches = []
+      }
       port "metrics" {
         to = 9090
       }
@@ -154,13 +164,13 @@ job "backup-worker" {
       }
 
       # --- Resources ---
-      # Registry backup tars ~600MB of data; needs memory headroom for gzip
-      # bursts. Steady-state usage is ~30 MiB, so request stays small and
-      # memory_max permits the burst when a registry backup runs.
+      # Steady-state usage is ~30 MiB, but the Postgres + Registry backup
+      # activities OOM when run with memory=96/memory_max=768 (exit 137 on
+      # every dump after the patroni restart cycle). Keeping memory at the
+      # historical 512 MiB; CPU is safely high already.
       resources {
-        cpu        = 2000
-        memory     = 96
-        memory_max = 768
+        cpu    = 2000
+        memory = 512
       }
 
       kill_timeout = "30s"


### PR DESCRIPTION
Closes #48.

## Summary
Catch-all PR for the fallout that surfaced after right-sizing in #42:

- **backup-worker memory revert** (`96/memory_max=768` → `512`). The post-rightsize sample didn't include a real backup window, so the cut was too aggressive — alloc OOM-killed (exit 137) on every Postgres dump.
- **backup-worker container DNS** (`dns { servers = ["127.0.0.53"], searches = [] }`). The container was using pi-hole as resolver, so `.consul` lookups fell through to NXDOMAIN, search-domain expansion caught the `*.munchbox.cc → 192.168.68.60` wildcard, and `s3-orchestrator.service.consul` resolved to goren — which doesn't host s3-orchestrator. Every PutObject failed with `connection refused 192.168.68.60:9000`.
- **s3-orchestrator memory bump** (`512/memory_max=1000` → `1024`). OOM-killed under load (aptly push + e2-quota retry storm). Steady-state is ~15 MiB; bursts blow through 1000.
- **src/oracle-watchdog submodule bump** to pick up the v1.4.1 CHANGELOG commit. The v1.4.1 image itself was already deployed back in #29.

## Test plan
- [ ] backup-worker re-deploy + manual workflow trigger; expect Postgres dump + S3 upload to complete end-to-end.
- [ ] s3-orchestrator re-deploy; confirm alloc stays up across an aptly publish.
- [ ] No new submodule drift on a fresh clone.