### PR TITLE
GH_ISSUE_55: cap journald disk usage cluster-wide

### DIFF
--- a/infrastructure/ansible/playbooks/cap-journald.yml
+++ b/infrastructure/ansible/playbooks/cap-journald.yml
@@ -1,0 +1,65 @@
+---
+# -------------------------------------------------------------------------------
+# Cap journald disk usage cluster-wide
+#
+# Project: Munchbox / Author: Alex Freidah
+#
+# Drops a /etc/systemd/journald.conf.d/limits.conf override on every host so the
+# persistent journal can't grow unbounded. nomad-server-03 had 2.9 GB of
+# /var/log/journal on a 30 GB disk before this. Caps total persistent journal
+# at 500 MiB and per-file at 50 MiB.
+#
+# Usage:
+#   ansible-playbook -i inventory/bare-metal.ini -i inventory/hosts.yml \
+#                    playbooks/cap-journald.yml
+# -------------------------------------------------------------------------------
+
+- name: Cap journald disk usage
+  hosts: all
+  become: true
+  gather_facts: false
+
+  tasks:
+    - name: Ensure journald drop-in directory exists
+      ansible.builtin.file:
+        path: /etc/systemd/journald.conf.d
+        state: directory
+        owner: root
+        group: root
+        mode: "0755"
+
+    - name: Deploy journald size cap
+      ansible.builtin.copy:
+        dest: /etc/systemd/journald.conf.d/limits.conf
+        owner: root
+        group: root
+        mode: "0644"
+        content: |
+          # Managed by Ansible — playbooks/cap-journald.yml
+          [Journal]
+          SystemMaxUse=500M
+          SystemMaxFileSize=50M
+      notify: restart systemd-journald
+
+    - name: Force immediate vacuum to enforce the new cap
+      # Restarting journald picks up the config, but it only enforces on
+      # rotation. Vacuum forces it to drop already-archived files above the
+      # cap so the existing oversize journals shrink right away.
+      ansible.builtin.command: journalctl --vacuum-size=500M
+      register: journal_vacuum
+      changed_when: "'Deleted archived journal' in journal_vacuum.stderr or 'Vacuuming done' in journal_vacuum.stderr"
+
+    - name: Show post-vacuum disk usage
+      ansible.builtin.command: journalctl --disk-usage
+      register: journal_usage
+      changed_when: false
+
+    - name: Display result
+      ansible.builtin.debug:
+        msg: "{{ inventory_hostname }}: {{ journal_usage.stdout }}"
+
+  handlers:
+    - name: restart systemd-journald
+      ansible.builtin.systemd:
+        name: systemd-journald
+        state: restarted


### PR DESCRIPTION
Closes #55.

## Summary
Adds `playbooks/cap-journald.yml` which drops `/etc/systemd/journald.conf.d/limits.conf` on every host (SystemMaxUse=500M, SystemMaxFileSize=50M), restarts journald, and runs `journalctl --vacuum-size=500M` to enforce the cap immediately on existing archives.

## Why the immediate vacuum
Restarting journald picks up the new config but only enforces it on rotation — without the vacuum step, existing oversize archives would sit around until they happened to roll over. Vacuum forces the cleanup right away, which is what made nomad-server-03 actually shrink today.

## Result of the first run
Every node now under 500 MiB journal:
- nomad-server-03 root: **29% → 21%** (~2.5 GB freed)
- All other nodes within margin (most had been 400–500 MiB already, just no enforcement before)

## Test plan
- [x] Playbook applied cleanly to all 18 hosts (proxmox hypervisors, Pi5s, Nomad VMs, Pi-hole, Oracle).
- [x] All hosts report `journalctl --disk-usage` < 500 MiB after the run.
- [x] No service flapped during the journald restart.
- [ ] Spot-check a week from now that growth stays under the cap (it will — just confirming no surprise log floods).