### PR TITLE
GH_ISSUE_50: tighten rsyslog rotation on Oracle ARM nodes

### DIFF
--- a/infrastructure/ansible/playbooks/tighten-rsyslog-rotation.yml
+++ b/infrastructure/ansible/playbooks/tighten-rsyslog-rotation.yml
@@ -1,0 +1,74 @@
+---
+# -------------------------------------------------------------------------------
+# Tighten rsyslog rotation on Oracle ARM nodes
+#
+# Project: Munchbox / Author: Alex Freidah
+#
+# The stock Ubuntu /etc/logrotate.d/rsyslog rotates weekly and keeps 4
+# generations, which let oracle-arm-1's syslog.1 grow to 3.6 GB on a 48 GB
+# root. Switches to daily rotation with a 200 MiB out-of-cycle trigger so
+# the rotated file is bounded.
+#
+# Scoped to the Oracle ARM nodes only — that's where the disk pressure is
+# (oracle-arm-1 was at 68% used). The AMD oracle-node-* boxes don't have the
+# same problem (no docker / minio storage) so they're left alone.
+#
+# Usage:
+#   ansible-playbook -i inventory/hosts.yml playbooks/tighten-rsyslog-rotation.yml
+# -------------------------------------------------------------------------------
+
+- name: Tighten rsyslog rotation on Oracle ARM nodes
+  hosts: oracle-arm-1:oracle-arm-2
+  become: true
+  gather_facts: false
+
+  tasks:
+    - name: Replace /etc/logrotate.d/rsyslog with tightened config
+      ansible.builtin.copy:
+        dest: /etc/logrotate.d/rsyslog
+        owner: root
+        group: root
+        mode: "0644"
+        content: |
+          # Managed by Ansible — playbooks/tighten-rsyslog-rotation.yml
+          /var/log/syslog
+          /var/log/mail.log
+          /var/log/kern.log
+          /var/log/auth.log
+          /var/log/user.log
+          /var/log/cron.log
+          {
+              rotate 7
+              daily
+              size 200M
+              missingok
+              notifempty
+              compress
+              delaycompress
+              sharedscripts
+              # /var/log is group-writable by syslog, so logrotate refuses
+              # to rotate without an explicit su directive telling it which
+              # user/group to drop to.
+              su root syslog
+              postrotate
+                  /usr/lib/rsyslog/rsyslog-rotate
+              endscript
+          }
+
+    - name: Force immediate rotation so the existing oversize files get drained
+      ansible.builtin.command: logrotate -f /etc/logrotate.d/rsyslog
+      register: rotate_result
+      changed_when: true
+
+    - name: Show post-rotation /var/log usage
+      ansible.builtin.shell: |
+        du -sh /var/log
+        ls -lh /var/log/syslog* 2>/dev/null | head -8 || true
+      args:
+        executable: /bin/bash
+      register: var_log_usage
+      changed_when: false
+
+    - name: Display result
+      ansible.builtin.debug:
+        msg: "{{ inventory_hostname }}:\n{{ var_log_usage.stdout }}"


### PR DESCRIPTION
Closes #50.

## Summary
Replaces the stock `/etc/logrotate.d/rsyslog` on `oracle-arm-1` and `oracle-arm-2` with a tightened version: daily rotation + 200 MiB out-of-cycle trigger, 7 generations, plus `su root syslog` so logrotate doesn't refuse on the group-writable `/var/log`.

## Why scoped to ARM only
The AMD `oracle-node-1/2` boxes don't have docker/minio data eating into their roots and weren't anywhere near full. The pressure is exclusively on the ARM nodes. Could broaden later if the AMD nodes start drifting.

## Result of the first run
- oracle-arm-1: **68% → 62%** (~3 GB freed; previous 3.6 GB `syslog.1` rotated and compressed to 436 MiB)
- oracle-arm-2: essentially flat (didn't have the bloat)

## Test plan
- [x] Playbook applied cleanly to both ARM nodes after adding the `su` directive (initial run failed because logrotate refuses on insecure parent dirs without it).
- [x] `rsyslog` continued running across rotation; new `/var/log/syslog` is being written.
- [ ] Confirm tomorrow's automatic logrotate cycle compresses today's `syslog.1` and rolls cleanly.