### PR TITLE
GH_ISSUE_54: cluster-wide apt cleanup playbook

### DIFF
--- a/infrastructure/ansible/playbooks/apt-cleanup.yml
+++ b/infrastructure/ansible/playbooks/apt-cleanup.yml
@@ -1,0 +1,53 @@
+---
+# -------------------------------------------------------------------------------
+# Cluster-wide apt cleanup
+#
+# Project: Munchbox / Author: Alex Freidah
+#
+# Runs `apt autoremove --purge -y` and `apt clean` on every Debian/Ubuntu host
+# to drop unused packages (especially old kernel images) and the package cache.
+# Idempotent — safe to re-run on a schedule.
+#
+# Usage:
+#   ansible-playbook -i inventory/bare-metal.ini -i inventory/hosts.yml \
+#                    playbooks/apt-cleanup.yml
+# -------------------------------------------------------------------------------
+
+- name: Cluster-wide apt cleanup
+  hosts: all
+  become: true
+  gather_facts: false
+
+  tasks:
+    - name: Capture / usage before cleanup
+      ansible.builtin.command: df -h --output=used,avail,pcent /
+      register: before_df
+      changed_when: false
+
+    - name: Autoremove unused packages including old kernels
+      # purge=true drops config files for removed packages, too. Retry the
+      # apt lock briefly in case unattended-upgrades is mid-run.
+      ansible.builtin.apt:
+        autoremove: true
+        purge: true
+        autoclean: false
+      register: autoremove
+      retries: 3
+      delay: 30
+      until: autoremove is succeeded
+
+    - name: Clean the package cache (/var/cache/apt/archives/)
+      ansible.builtin.apt:
+        clean: true
+
+    - name: Capture / usage after cleanup
+      ansible.builtin.command: df -h --output=used,avail,pcent /
+      register: after_df
+      changed_when: false
+
+    - name: Display before/after
+      ansible.builtin.debug:
+        msg: |
+          {{ inventory_hostname }}
+            before: {{ before_df.stdout_lines[1] | trim }}
+            after:  {{ after_df.stdout_lines[1] | trim }}


### PR DESCRIPTION
Closes #54.

## Summary
`playbooks/apt-cleanup.yml` runs `apt autoremove --purge` + `apt clean` on every Debian/Ubuntu host. Picks up the apt lock retry behavior so unattended-upgrades doesn't trip the run.

## Result of the first invocation
17/18 hosts cleared 100-500 MiB each on the first run. `oracle-node-2` needed a one-time manual `sudo dpkg --configure -a` first (its dpkg state was wedged from a prior interrupted operation — same node that's been flaky throughout recent sessions). After that fix it succeeded too (6.6G → 6.1G).

## Test plan
- [x] Played cleanly on all 18 hosts after the dpkg unwedge.
- [x] No services flapped.
- [ ] Future: schedule via cron / systemd timer / Ansible periodic so it doesn't have to be invoked manually.