### PR TITLE
GH_ISSUE_40: tear down legacy stabler-only WireGuard server

### DIFF
--- a/infrastructure/ansible/inventory/bare-metal.ini
+++ b/infrastructure/ansible/inventory/bare-metal.ini
@@ -81,8 +81,11 @@ oracle_nodes
 # WireGuard Groups
 # -------------------------------------------------------------------------------
 
+# Empty post-#29 cutover. Home-side WG now runs as the wireguard-server
+# Nomad job on the ingress pair (goren + nomad-client-05) behind the
+# 192.168.68.49 VRRP VIP. Group kept defined so wireguard_nodes:children
+# below still resolves.
 [wireguard_server]
-stabler ansible_host=192.168.68.61 wireguard_role=server
 
 [wireguard_clients:children]
 oracle_nodes

--- a/infrastructure/ansible/playbooks/wireguard-teardown-stabler.yml
+++ b/infrastructure/ansible/playbooks/wireguard-teardown-stabler.yml
@@ -1,0 +1,57 @@
+---
+# -------------------------------------------------------------------------------
+# Tear down the legacy stabler-only WireGuard server config
+#
+# Project: Munchbox / Author: Alex Freidah
+#
+# After the WG HA cutover (issue #29), the home end of the WG tunnel runs
+# as a Nomad job on the ingress pair (goren + nomad-client-05) behind the
+# 192.168.68.49 VRRP VIP. Stabler's old wg-quick@wg0 unit and
+# /etc/wireguard/wg0.conf were left behind during the cutover so we could
+# roll back. Confirmed safe to drop now: stabler's wg0 has had no peer
+# handshakes for 1+ days because all Oracle clients connect to the
+# wg.munchbox.cc endpoint instead.
+#
+# Leaves the keypair (/etc/wireguard/{private,public}.key) in place so we
+# can re-enable later if needed without re-bootstrapping. Does not
+# uninstall the wireguard package — keeping `wg show` available for ops.
+#
+# Usage:
+#   ansible-playbook -i inventory/bare-metal.ini -i inventory/hosts.yml \
+#                    playbooks/wireguard-teardown-stabler.yml
+# -------------------------------------------------------------------------------
+
+- name: Tear down stabler legacy WireGuard server
+  hosts: stabler
+  become: true
+  gather_facts: false
+
+  tasks:
+    - name: Stop and disable wg-quick@wg0
+      ansible.builtin.systemd:
+        name: wg-quick@wg0
+        state: stopped
+        enabled: false
+      register: wg_systemd
+      failed_when:
+        - wg_systemd is failed
+        - "'Could not find the requested service' not in (wg_systemd.msg | default(''))"
+
+    - name: Remove /etc/wireguard/wg0.conf (keypair preserved for possible re-enable)
+      ansible.builtin.file:
+        path: /etc/wireguard/wg0.conf
+        state: absent
+
+    - name: Confirm wg0 interface is gone
+      ansible.builtin.command: ip link show wg0
+      register: wg0_check
+      failed_when: false
+      changed_when: false
+
+    - name: Display result
+      ansible.builtin.debug:
+        msg: |
+          {{ inventory_hostname }}:
+            wg-quick@wg0: stopped + disabled
+            /etc/wireguard/wg0.conf: removed
+            wg0 interface: {{ 'gone' if wg0_check.rc != 0 else 'still present (manual cleanup may be needed)' }}


### PR DESCRIPTION
Closes #40.

## Summary
Final cleanup from the WG HA cutover (#29). Removes stabler's leftover `wg-quick@wg0` unit + config; the home-side WG tunnel has been served by the `wireguard-server` Nomad job on the ingress pair (goren + nomad-client-05) behind the `192.168.68.49` VRRP VIP for a while now.

## What lands
- `playbooks/wireguard-teardown-stabler.yml` — stops + disables `wg-quick@wg0`, removes `/etc/wireguard/wg0.conf`. Keypair is preserved (so we could re-bootstrap if needed) and the `wireguard` package stays (so `wg show` is still around for ops).
- `inventory/bare-metal.ini` — empties the `[wireguard_server]` group; group kept defined so `wireguard_nodes:children` still resolves cleanly.

## Why now (and how I confirmed it was safe)
Stabler's `wg show wg0` showed all 3 Oracle peers with last-handshake of 1+ days ago — meaning no client was actually using stabler's tunnel anymore. The peers had quietly migrated to the `wg.munchbox.cc` endpoint when #29 landed; the only thing keeping stabler's wg0 around was inertia.

## Test plan
- [x] Playbook applied cleanly: wg0 interface gone on stabler.
- [x] All 4 Oracle nodes still `ready` in Nomad after teardown.
- [x] Goren's wg0 (the active ingress) shows recent handshakes from all 4 peers.
- [ ] Confirm Vault still has the legacy keypair if anyone wants to clean *that* up later (separate issue if pursued).