### PR TITLE
GH_ISSUE_53: wire periodic registry garbage-collection

### DIFF
--- a/nomad/jobs/temporal-workflows/cleanup-worker/cleanup-worker.nomad.hcl
+++ b/nomad/jobs/temporal-workflows/cleanup-worker/cleanup-worker.nomad.hcl
@@ -110,7 +110,7 @@ job "cleanup-worker" {
       }
 
       config {
-        image              = "registry.munchbox.cc/cleanup-worker:v0.1.0"
+        image              = "registry.munchbox.cc/cleanup-worker:v0.2.4"
         image_pull_timeout = "5m"
         network_mode       = "host"
         ports              = ["metrics"]

--- a/nomad/jobs/temporal-workflows/temporal-registry-gc-trigger.nomad.hcl
+++ b/nomad/jobs/temporal-workflows/temporal-registry-gc-trigger.nomad.hcl
@@ -1,0 +1,108 @@
+# -------------------------------------------------------------------------------
+# Registry GC Trigger - Scheduled Docker Registry Garbage-Collection
+#
+# Project: Munchbox / Author: Alex Freidah
+#
+# Periodic batch job that triggers the Temporal RegistryGC workflow weekly
+# at 02:00 PT on Sunday. The workflow scales the registry job to 0 for the
+# duration of GC (a brief outage of registry.munchbox.cc — minutes), runs
+# `registry garbage-collect` against the bind-mounted storage, then scales
+# the registry back to 1.
+#
+# DRY_RUN starts as true so the first scheduled run reports what would be
+# deleted without actually freeing space. Flip to false once the
+# alloc-scaling sequence has been observed end-to-end.
+# -------------------------------------------------------------------------------
+
+job "temporal-registry-gc-trigger" {
+  region      = "global"
+  datacenters = ["munchbox"]
+  type        = "batch"
+  node_pool   = "all"
+  priority    = 30
+
+  # ---------------------------------------------------------------------------
+  # Periodic Scheduling - Weekly, Sunday 02:00 PT
+  # ---------------------------------------------------------------------------
+  # Sunday early morning is the lowest CI / aptly-publish activity window.
+  # GC briefly takes registry.munchbox.cc offline (typically a few minutes).
+
+  periodic {
+    cron             = "0 2 * * 0"
+    time_zone        = "America/Los_Angeles"
+    prohibit_overlap = true
+  }
+
+  # ---------------------------------------------------------------------------
+  # Placement
+  # ---------------------------------------------------------------------------
+
+  constraint {
+    attribute = "${node.unique.name}"
+    operator  = "set_contains_any"
+    value     = "goren,stabler.munchbox.cc"
+  }
+
+  # ---------------------------------------------------------------------------
+  # Task Group: trigger
+  # ---------------------------------------------------------------------------
+
+  group "trigger" {
+    count = 1
+
+    network {
+      mode = "host"
+    }
+
+    restart {
+      attempts = 0
+      mode     = "fail"
+    }
+
+    reschedule {
+      attempts       = 0
+      interval       = "1h"
+      delay          = "5s"
+      delay_function = "constant"
+      unlimited      = false
+    }
+
+    # -------------------------------------------------------------------------
+    # Task: trigger
+    # -------------------------------------------------------------------------
+
+    task "trigger" {
+      driver = "docker"
+
+      config {
+        image              = "registry.munchbox.cc/backup-worker:v0.1.4"
+        image_pull_timeout = "10m"
+        entrypoint         = ["workflow-trigger"]
+        network_mode       = "host"
+      }
+
+      env {
+        TEMPORAL_ADDRESS            = "temporal-server.service.consul:7233"
+        WORKFLOW_NAME               = "registry-gc"
+        REGISTRY_JOB_NAME           = "registry"
+        REGISTRY_DATA_DIR           = "/mnt/gdrive/munchbox-data/registry"
+        REGISTRY_IMAGE              = "registry:3"
+        DRY_RUN                     = "true"
+        DELETE_UNTAGGED             = "true"
+        OTEL_EXPORTER_OTLP_ENDPOINT = "tempo.service.consul:4317"
+      }
+
+      resources {
+        cpu    = 50
+        memory = 64
+      }
+
+      kill_timeout = "30s"
+      kill_signal  = "SIGTERM"
+    }
+  }
+
+  meta = {
+    project = "munchbox"
+  }
+}


### PR DESCRIPTION
Closes #53.

## Summary
Munchbox-side wiring for the registry GC workflow shipped in afreidah/nomad-temporal-jobs#16 + the saga refactor #18. Three changes plus the submodule bump:

- **`cleanup-worker.nomad.hcl`** — image v0.1.0 → v0.2.4 so the running worker has the new `RegistryGC` workflow registered (saga-decomposed: 6 small activities + a deferred scale-back compensation that always runs even on GC failure).
- **`temporal-registry-gc-trigger.nomad.hcl`** (new) — periodic batch firing `WORKFLOW_NAME=registry-gc` weekly at 02:00 PT Sunday. `DRY_RUN=true` for the first scheduled run; flip to false after one observed clean run. Mirrors the structure of the existing `temporal-{backup,cleanup,trivy}-trigger` jobs.
- **`src/nomad-temporal-jobs`** submodule pointer advanced to pick up the saga-refactored `RegistryGC` workflow (PRs #16 + #18).

The trigger image stays at `backup-worker:v0.1.4` (where the workflow-trigger binary lives). After `make push-all` from the submodule, that tag was overwritten with the rebuilt binary that includes the `case "registry-gc"` dispatch.

## Test plan
- [x] cleanup-worker deploys clean at v0.2.4.
- [x] temporal-registry-gc-trigger registers + Nomad shows the periodic job scheduled.
- [ ] First DRY_RUN execution (either Sunday at 02:00 or via `nomad job dispatch -periodic-force temporal-registry-gc-trigger`): verify the saga runs all 6 activities + the deferred scale-back in the Temporal UI.
- [ ] After one clean DRY_RUN, flip the env var to `DRY_RUN=false` and re-deploy.