### PR TITLE
GH_ISSUE_51: drop Prometheus retention to 14d; pin to goren

### DIFF
--- a/nomad/jobs/monitoring/prometheus/prometheus.hcl
+++ b/nomad/jobs/monitoring/prometheus/prometheus.hcl
@@ -17,16 +17,15 @@ host_network = true
 type  = "system"
 size  = "medium"
 
-# --- Placement: ingress nodes only ---
-# TODO(wg-ha): the backup ingress node's wg0 has the 10.200.0.0/24 route
-# but no learned peer endpoints, so its prometheus instance can't reach
-# Oracle exporters and false-alerts on a cascade. Real fix is to bring
-# wg0 up only on the node currently holding the WG VIP (sync wg0 to the
-# keepalived MASTER state via notify_master/notify_backup). Until then,
-# expect spurious "Oracle scrape failed" alerts from the backup-ingress
-# prometheus instance.
+# --- Placement: goren only (WG-HA workaround) ---
+# Backup ingress (nomad-client-05) has wg0 up but no live peer state with
+# Oracle nodes, so its prometheus replica false-alerted on every Oracle
+# target. Pinning to goren — the VRRP MASTER, the only ingress that
+# actually holds Oracle peer state — gives us consistent scrape results
+# at the cost of losing prometheus HA. Un-pin once #39 (WG-HA
+# active/active) lands.
 constraints = [
-  { attribute = "$${meta.role}", operator = "=", value = "ingress" }
+  { attribute = "$${node.unique.name}", operator = "=", value = "goren" }
 ]
 vault = true
 
@@ -59,7 +58,7 @@ args = [
   "--web.enable-lifecycle",
   "--web.enable-admin-api",
   "--web.enable-remote-write-receiver",
-  "--storage.tsdb.retention.time=30d",
+  "--storage.tsdb.retention.time=14d",
   "--storage.tsdb.wal-compression",
   "--web.page-title=Munchbox Prometheus",
   "--enable-feature=exemplar-storage"


### PR DESCRIPTION
## Summary
- Prometheus TSDB retention 30d → 14d (frees ~5 GB per replica, ~10 GB cluster-wide; we only need short-horizon data for dashboards + alerting)
- Pin prometheus to goren — the nc05 replica false-alerts on Oracle targets because its wg0 has no live peer state. Workaround until #39 lands.

Closes #51

## Test plan
- [ ] `make run JOB=prometheus` — alloc rolls onto goren, old nc05 alloc stops
- [ ] confirm only one prometheus alloc running (`nomad job allocs prometheus`)
- [ ] confirm older TSDB blocks get pruned (disk usage drops within a couple of minutes)
- [ ] grafana dashboards still respond