### PR TITLE
GH_ISSUE_64: shorten vault-cert-manager TTL 90d → 30d

### DIFF
--- a/infrastructure/ansible/playbooks/vault-cert-manager.yml
+++ b/infrastructure/ansible/playbooks/vault-cert-manager.yml
@@ -32,7 +32,7 @@
       common_name: "client.{{ consul_datacenter }}.consul"
       certificate: /etc/consul.d/tls/consul.crt
       key: /etc/consul.d/tls/consul.key
-      ttl: 2160h
+      ttl: 720h
       alt_names:
         - localhost
         - "{{ inventory_hostname }}"
@@ -55,7 +55,7 @@
       common_name: "server.{{ consul_datacenter }}.consul"
       certificate: /etc/consul.d/tls/consul.crt
       key: /etc/consul.d/tls/consul.key
-      ttl: 2160h
+      ttl: 720h
       alt_names:
         - localhost
         - "{{ inventory_hostname }}"
@@ -78,7 +78,7 @@
       common_name: "client.{{ nomad_region | default('global') }}.nomad"
       certificate: /etc/nomad.d/tls/nomad.crt
       key: /etc/nomad.d/tls/nomad.key
-      ttl: 2160h
+      ttl: 720h
       alt_names:
         - localhost
         - "{{ inventory_hostname }}"
@@ -101,7 +101,7 @@
       common_name: "server.{{ nomad_region | default('global') }}.nomad"
       certificate: /etc/nomad.d/tls/nomad.crt
       key: /etc/nomad.d/tls/nomad.key
-      ttl: 2160h
+      ttl: 720h
       alt_names:
         - localhost
         - "{{ inventory_hostname }}"
@@ -126,7 +126,7 @@
       common_name: "server.{{ nomad_region | default('global') }}.nomad"
       certificate: /etc/nomad.d/tls/nomad.crt
       key: /etc/nomad.d/tls/nomad.key
-      ttl: 2160h
+      ttl: 720h
       alt_names:
         - localhost
         - "{{ inventory_hostname }}"


### PR DESCRIPTION
## Summary
- All five vault-cert-manager cert templates: `ttl: 2160h` (90d) → `ttl: 720h` (30d)
- Cuts blast radius if a key leaks and surfaces broken renewal automation in ~15d instead of ~45d
- Existing 90d certs keep going until they hit their normal renewal threshold, then issue at 30d

Closes #64

## Test plan
- [x] `ansible-playbook -i inventory/hosts.yml playbooks/vault-cert-manager.yml` rolled clean to all 15 nodes
- [ ] confirm next cert renewal cycle (within ~38d) issues at 720h TTL via `managed_cert_not_after_timestamp_seconds`
- [ ] confirm subsequent renewal fires at ~15d post-issue, not ~45d