### PR TITLE
GH_ISSUE_74: bump gitgogit memory 128 -> 256 MiB

### DIFF
--- a/nomad/jobs/infrastructure/gitgogit/gitgogit.nomad.hcl
+++ b/nomad/jobs/infrastructure/gitgogit/gitgogit.nomad.hcl
@@ -242,7 +242,7 @@ daemon:
 
       resources {
         cpu    = 200
-        memory = 128
+        memory = 256
       }
 
       kill_timeout = "30s"


### PR DESCRIPTION
## Summary
- Bumps the gitgogit alloc from 128 -> 256 MiB so the periodic munchbox fetch can't get OOM-killed mid-clone (current symptom: `fetch: signal: killed` -> full re-clone next cycle).

## Test plan
- [x] Deployed
- [x] Alloc running healthy
- [ ] Next scheduled sync cycle of munchbox completes without re-clone

Closes #74