### PR TITLE
GH_ISSUE_76: open Oracle iptables for wg1 mesh traffic

### DIFF
--- a/infrastructure/ansible/roles/wireguard/templates/wg-server.conf.j2
+++ b/infrastructure/ansible/roles/wireguard/templates/wg-server.conf.j2
@@ -16,9 +16,13 @@ ListenPort = {{ wireguard_port }}
 PrivateKey = {{ wireguard_private_key }}
 MTU = {{ wireguard_mtu }}
 
-# Open local iptables for inbound WG traffic on the public interface
+# Open local iptables for inbound WG traffic on the public interface,
+# and accept everything coming in over the WG interface itself (mesh traffic
+# from goren + nc05 to nomad/consul/vault scrape endpoints, etc).
 PostUp = iptables -I INPUT -p udp --dport {{ wireguard_port }} -j ACCEPT
+PostUp = iptables -I INPUT -i {{ wireguard_interface }} -j ACCEPT
 PostDown = iptables -D INPUT -p udp --dport {{ wireguard_port }} -j ACCEPT
+PostDown = iptables -D INPUT -i {{ wireguard_interface }} -j ACCEPT
 
 [Peer]
 # goren — carries the 192.168.68.0/24 return route


### PR DESCRIPTION
## Summary
- Adds \`iptables -I INPUT -i {{ wireguard_interface }} -j ACCEPT\` to the wg-server PostUp (matching PostDown) so wg-quick owns the mesh-accept rule.
- After the reverse-WG cutover (#70), the leftover \`-i wg0 ACCEPT\` was dead, and any port outside the explicit allow rules (notably nomad-client on 4646) was rejected with icmp-host-prohibited — caught when oracle-node-2 went unhealthy in Prometheus.

## Test plan
- [x] Live state on all 4 oracles matches the template (rule applied; verified iptables shows wg1 ACCEPT)
- [x] Prometheus \`up{job="nomad-client"}\` = 1 on every node

Closes #76