### PR TITLE
GH_ISSUE_32: pin Nomad node name on oracle nodes + fix stale wg0 ref

### DIFF
--- a/infrastructure/ansible/inventory/group_vars/oracle_nodes.yml
+++ b/infrastructure/ansible/inventory/group_vars/oracle_nodes.yml
@@ -42,7 +42,8 @@ consul_bind_addr: "{{ static_ip }}"
 nomad_bind_addr: "{{ static_ip }}"
 
 # Use WireGuard interface for bridge networking so services register with WireGuard IP
-nomad_network_interface: "wg0"
+# (post-#70 reverse-WG cutover: oracles use wg1, not wg0 — wg0 is retired)
+nomad_network_interface: "wg1"
 
 # Note: nomad_advertise_* addresses are now computed automatically from static_ip
 # in roles/nomad/defaults/main.yml using nomad_advertise_ip variable
@@ -125,6 +126,11 @@ nomad_tls_rpc: true
 # -------------------------------------------------------------------------------
 
 nomad_node_pool: "oracle"
+
+# Pin the Nomad node name to the OS-hostname form (no hyphens) that Nomad
+# currently advertises. Constraints in jobs/* use this form; ansible inventory
+# uses the hyphenated form (oracle-node-1). See #32.
+nomad_node_name: "{{ inventory_hostname | replace('-', '') }}"
 
 nomad_client_meta:
   cloud: "oracle"

--- a/infrastructure/ansible/roles/nomad/templates/nomad.hcl.j2
+++ b/infrastructure/ansible/roles/nomad/templates/nomad.hcl.j2
@@ -7,6 +7,11 @@
 # -------------------------------------------------------------------------------
 datacenter = "{{ nomad_datacenter }}"
 region = "{{ nomad_region }}"
+{% if nomad_node_name is defined %}
+# Pin the advertised node name so it can't drift if the OS hostname changes
+# (see #32). Constraints like `node.unique.name = "oraclenode1"` match this.
+name = "{{ nomad_node_name }}"
+{% endif %}
 data_dir = "{{ nomad_data_dir }}"
 log_level = "INFO"
 bind_addr = "{{ nomad_bind_addr }}"


### PR DESCRIPTION
## Summary
- Adds an opt-in \`name = \"...\"\` line to the nomad agent template, gated on a new \`nomad_node_name\` var. Default behavior unchanged.
- Sets \`nomad_node_name: \"{{ inventory_hostname | replace('-', '') }}\"\` in \`group_vars/oracle_nodes.yml\`, which pins all four oracles to the no-hyphen form Nomad already advertises (\`oraclenode1\`, \`oraclearm2\`, etc.). Constraints in jobs/* match this form today; the hyphenated form from ansible inventory would silently no-op.
- Flips \`nomad_network_interface\` from \`wg0\` -> \`wg1\` on the same group. Post-#70 the amd64 oracles already crash-looped on the stale wg0; arm oracles were holding cached state from before the cutover and would have died on the next restart.

## Test plan
- [x] Live state on all 4 oracles matches the rendered template (name line + wg1)
- [x] All 4 oracles \`ready\` post-restart; no allocs reshuffled
- [ ] Next full ansible run is a no-op against oracle_nodes

Closes #32