### PR TITLE
GH_ISSUE_85: add munchbox_base cookbook

### DIFF
--- a/infrastructure/cinc/cookbooks/munchbox_base/.gitignore
+++ b/infrastructure/cinc/cookbooks/munchbox_base/.gitignore
@@ -1,0 +1,12 @@
+# --- Test-kitchen state (per-VM logs, vagrant artifacts) ---
+.kitchen/
+kitchen.local.yml
+
+# --- Editor / language-server scratch ---
+.ruby-lsp/
+
+# --- Bundler vendor dir if installed locally ---
+vendor/bundle/
+
+# --- Berkshelf lock file (cookbook dep resolution result) ---
+Berksfile.lock

--- a/infrastructure/cinc/cookbooks/munchbox_base/.rubocop.yml
+++ b/infrastructure/cinc/cookbooks/munchbox_base/.rubocop.yml
@@ -1,7 +1,7 @@
 # -------------------------------------------------------------------------------
-# Cookstyle (rubocop) config for munchbox_lib.
+# Cookstyle (rubocop) config for munchbox_base.
 #
-# Inherits cookstyle defaults; overrides below are project-specific only.
+# Inherits cookstyle defaults; project-specific overrides only.
 # -------------------------------------------------------------------------------
 
 require:
@@ -23,7 +23,8 @@ AllCops:
 Layout/LineLength:
   Max: 120
 
-# --- Specs use long descriptions; don't fight rspec idioms ---
+# --- Specs + inspec controls use long describe blocks; don't fight that ---
 Metrics/BlockLength:
   Exclude:
     - 'spec/**/*'
+    - 'test/**/*'

--- a/infrastructure/cinc/cookbooks/munchbox_base/Berksfile
+++ b/infrastructure/cinc/cookbooks/munchbox_base/Berksfile
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+# -------------------------------------------------------------------------------
+# Berksfile for munchbox_base
+#
+# Resolves the cookbook + its deps for test-kitchen. `source chef_repo: '../..'`
+# points at infrastructure/cinc/ so berks finds the sibling cookbooks/
+# directory (where munchbox_lib lives). `metadata` pulls dep declarations
+# from metadata.rb in this dir.
+# -------------------------------------------------------------------------------
+
+source chef_repo: '../..'
+
+metadata

--- a/infrastructure/cinc/cookbooks/munchbox_base/Makefile
+++ b/infrastructure/cinc/cookbooks/munchbox_base/Makefile
@@ -1,0 +1,63 @@
+# -------------------------------------------------------------------------------
+# Cookbook:: munchbox_base
+# Makefile
+#
+# All targets delegate to cinc-workstation tools wrapped in /usr/local/bin
+# (which env -i to isolate from any RVM/bundler pollution). Bootstrap the
+# toolchain once with `make tools` -- after that everything just works.
+#
+#   make tools    - install cinc-workstation + libvirt/vagrant stack
+#   make lint     - cookstyle
+#   make test     - chefspec/rspec via chef's bundled rspec
+#   make kitchen  - full test-kitchen run (create + converge + verify + destroy)
+#   make verify   - kitchen verify only (VM already up)
+#   make destroy  - tear down the kitchen VM
+# -------------------------------------------------------------------------------
+
+# --- Absolute paths to the cinc wrappers so RVM/rbenv PATH ordering can't win ---
+CHEF      := /usr/local/bin/chef
+COOKSTYLE := /usr/local/bin/cookstyle
+KITCHEN   := /usr/local/bin/kitchen
+
+.PHONY: help tools test lint kitchen create converge verify login destroy
+
+help:
+	@echo "make tools     - install cinc-workstation + libvirt/vagrant stack (one-time host setup)"
+	@echo "make lint      - cookstyle (rubocop with chef cops)"
+	@echo "make test      - chefspec/rspec unit tests"
+	@echo ""
+	@echo "Kitchen lifecycle (run in order, or use 'make kitchen' to do all in one shot):"
+	@echo "  make create    - provision the VM (vagrant up)"
+	@echo "  make converge  - run cinc-client on the VM"
+	@echo "  make verify    - run inspec controls against the converged VM"
+	@echo "  make login     - ssh into the VM"
+	@echo "  make destroy   - tear the VM down"
+	@echo ""
+	@echo "  make kitchen   - create + converge + verify + destroy in one go"
+
+tools:
+	../../scripts/kitchen/debian.sh
+
+lint:
+	$(COOKSTYLE) .
+
+test:
+	$(CHEF) exec rspec spec/
+
+kitchen:
+	$(KITCHEN) test
+
+create:
+	$(KITCHEN) create
+
+converge:
+	$(KITCHEN) converge
+
+verify:
+	$(KITCHEN) verify
+
+login:
+	$(KITCHEN) login
+
+destroy:
+	$(KITCHEN) destroy

--- a/infrastructure/cinc/cookbooks/munchbox_base/README.md
+++ b/infrastructure/cinc/cookbooks/munchbox_base/README.md
@@ -1,0 +1,91 @@
+# munchbox_base
+
+Base cookbook. Ships the OS-level prerequisites every Munchbox node depends
+on, exposed as small targeted resources + per-concern recipes so consumers
+cherry-pick exactly what they need.
+
+`default.rb` is intentionally empty. Add the specific recipes to a node's run
+list (or include them from a role) rather than pulling the whole cookbook.
+
+## Resources
+
+| Resource | Purpose |
+|---|---|
+| `munchbox_base_apt_repo` | Add an apt repository + signing key (idempotent) |
+| `munchbox_base_packages` | Install (or remove) a set of apt packages |
+| `munchbox_base_timesync` | Configure systemd-timesyncd via conf.d drop-in |
+| `munchbox_base_journald` | Apply journald disk/retention limits via conf.d drop-in |
+| `munchbox_base_sshd` | Apply sshd hardening via sshd_config.d drop-in |
+
+Each resource exposes a `:configure` (default) and `:remove` action.
+
+## Recipes
+
+| Recipe | What it converges |
+|---|---|
+| `munchbox_base::default` | empty — intentional |
+| `munchbox_base::apt_repo` | register the munchbox aptly repo |
+| `munchbox_base::packages` | install the baseline package set |
+| `munchbox_base::timesync` | configure NTP via systemd-timesyncd |
+| `munchbox_base::journald` | apply journald size + retention limits |
+| `munchbox_base::sshd` | apply sshd hardening drop-in |
+
+Typical node run_list:
+
+```
+recipe[munchbox_base::apt_repo]
+recipe[munchbox_base::packages]
+recipe[munchbox_base::timesync]
+recipe[munchbox_base::journald]
+recipe[munchbox_base::sshd]
+```
+
+## Usage
+
+```ruby
+# metadata.rb of a node-level role cookbook (or via run_list)
+depends 'munchbox_base'
+```
+
+Override attributes as needed:
+
+```ruby
+# in a role
+default_attributes(
+  'munchbox_base' => {
+    'packages' => %w(vim git my-extra-tool),
+    'timesync' => { 'ntp_servers' => %w(internal-ntp.munchbox.cc) },
+  }
+)
+```
+
+Iptables is intentionally *not* managed here — that comes later as a
+per-cookbook rule contribution pattern. Otherwise a converge of any
+`munchbox_base` recipe would risk clobbering service-specific rules from
+other cookbooks.
+
+## Development
+
+All tooling comes from **cinc-workstation** (bundles chef + kitchen + inspec
++ cookstyle + chefspec). One-time host setup:
+
+```
+make tools
+```
+
+That installs cinc-workstation, libvirt/KVM/vagrant-libvirt, and the
+`/usr/local/bin` wrappers that `env -i` cinc tools so RVM/rbenv/bundler env
+can't pollute them.
+
+After that:
+
+```
+make lint     # cookstyle
+make test     # rspec + chefspec (unit)
+make kitchen  # full test-kitchen (libvirt VM converge + inspec verify)
+make verify   # rerun inspec against an already-up VM
+make destroy  # tear the VM back down
+```
+
+Targets `bento/debian-12` via vagrant-libvirt to match the cookbook's
+`supports`.

--- a/infrastructure/cinc/cookbooks/munchbox_base/attributes/default.rb
+++ b/infrastructure/cinc/cookbooks/munchbox_base/attributes/default.rb
@@ -1,0 +1,98 @@
+# frozen_string_literal: true
+
+# -------------------------------------------------------------------------------
+# Cookbook:: munchbox_base
+# Attributes:: default
+#
+# Defaults for the wide base cookbook. Every entry is keyed under the
+# cookbook's namespace via `node[cookbook]`, so renaming the cookbook is a
+# one-line change in metadata.rb.
+# -------------------------------------------------------------------------------
+
+# -------------------------------------------------------------------------------
+# Apt packages
+#
+# Set installed on every Munchbox node. Keep this short -- anything specific to
+# a service belongs in that service's cookbook, not here.
+# -------------------------------------------------------------------------------
+
+default[cookbook]['packages'] = %w(
+  apt-transport-https
+  ca-certificates
+  curl
+  dnsutils
+  git
+  gnupg
+  htop
+  jq
+  lsb-release
+  net-tools
+  tmux
+  unattended-upgrades
+  vim
+)
+
+# -------------------------------------------------------------------------------
+# Munchbox apt repo
+#
+# Source list entry for the internal aptly-published repo (s3-backed, served
+# via traefik). Cookbooks that install custom .debs (e.g. moat, cinc) rely on
+# this being present.
+# -------------------------------------------------------------------------------
+
+default[cookbook]['apt_repo'] = {
+  'name' => 'munchbox',
+  'uri' => 'https://apt.munchbox.cc',
+  'distribution' => 'stable',
+  'components' => %w(main),
+  'key_url' => 'https://apt.munchbox.cc/pubkey.gpg',
+}
+
+# -------------------------------------------------------------------------------
+# Time sync (systemd-timesyncd)
+#
+# Override `ntp_servers` if you want to point at internal NTP. The fallback
+# pool keeps drift sane out of the box on fresh provisions.
+# -------------------------------------------------------------------------------
+
+default[cookbook]['timesync'] = {
+  'service' => 'systemd-timesyncd',
+  'ntp_servers' => %w(0.pool.ntp.org 1.pool.ntp.org 2.pool.ntp.org 3.pool.ntp.org),
+  'fallback_servers' => %w(time.cloudflare.com time.google.com),
+}
+
+# -------------------------------------------------------------------------------
+# Journald limits
+#
+# Bound how much disk journald can eat and how long entries stick around.
+# Bytes accept K/M/G suffixes; retention takes systemd time spans.
+# -------------------------------------------------------------------------------
+
+default[cookbook]['journald'] = {
+  'system_max_use' => '2G',
+  'system_keep_free' => '500M',
+  'runtime_max_use' => '200M',
+  'max_retention_sec' => '2week',
+  'max_level_store' => 'info',
+  'compress' => 'yes',
+}
+
+# -------------------------------------------------------------------------------
+# Sshd hardening
+#
+# Tunable directives merged into /etc/ssh/sshd_config (which we template
+# wholesale -- see munchbox_base::sshd). Add/override here rather than
+# editing the template.
+# -------------------------------------------------------------------------------
+
+default[cookbook]['ssh'] = {
+  'permit_root_login' => 'prohibit-password',
+  'password_authentication' => 'no',
+  'challenge_response_authentication' => 'no',
+  'pubkey_authentication' => 'yes',
+  'max_auth_tries' => 3,
+  'login_grace_time' => '30s',
+  'client_alive_interval' => 300,
+  'client_alive_count_max' => 2,
+  'x11_forwarding' => 'no',
+}

--- a/infrastructure/cinc/cookbooks/munchbox_base/kitchen.yml
+++ b/infrastructure/cinc/cookbooks/munchbox_base/kitchen.yml
@@ -1,0 +1,61 @@
+---
+# -------------------------------------------------------------------------------
+# Test-Kitchen config for munchbox_base.
+#
+# Real VMs via Vagrant because we exercise systemd units (timesyncd, journald,
+# sshd) -- docker containers won't cut it. Targets debian-12 to match the
+# cookbook's supports list.
+# -------------------------------------------------------------------------------
+
+driver:
+  name: vagrant
+  provider: libvirt
+  customize:
+    memory: 1024
+    cpus: 1
+
+provisioner:
+  name: chef_zero
+  product_name: cinc
+  product_version: latest
+  install_strategy: once
+  multiple_converge: 2
+  enforce_idempotency: true
+  chef_license: accept
+  log_level: warn
+
+verifier:
+  name: inspec
+  format: doc
+
+platforms:
+  - name: debian-12
+    driver:
+      box: generic/debian12
+
+suites:
+  - name: default
+    run_list:
+      - recipe[munchbox_base::apt_repo]
+      - recipe[munchbox_base::packages]
+      - recipe[munchbox_base::timesync]
+      - recipe[munchbox_base::journald]
+      - recipe[munchbox_base::sshd]
+    verifier:
+      inspec_tests:
+        - test/integration/default
+    attributes:
+      munchbox_base:
+        apt_repo:
+          # Public repo we use for the integration only -- apt.munchbox.cc
+          # isn't always reachable from a fresh kitchen VM, and we just need
+          # to prove the resource can register a working third-party repo.
+          name: nginx
+          uri: https://nginx.org/packages/debian
+          distribution: bookworm
+          components:
+            - nginx
+          key_url: https://nginx.org/keys/nginx_signing.key
+        packages:
+          - curl
+          - jq

--- a/infrastructure/cinc/cookbooks/munchbox_base/metadata.rb
+++ b/infrastructure/cinc/cookbooks/munchbox_base/metadata.rb
@@ -1,21 +1,26 @@
 # frozen_string_literal: true
 
 # -------------------------------------------------------------------------------
-# Cookbook:: munchbox_lib
+# Cookbook:: munchbox_base
 #
 # Project: Munchbox / Author: Alex Freidah
 #
-# Library-only cookbook. Holds shared helpers used by every other cookbook
-# in this repo (cookbook_name lookup, etc). No recipes, no resources, no
-# attributes - just `libraries/`.
+# Wide base cookbook. Runs on every node and owns OS-level prerequisites:
+# packages, apt repo, time sync, journald, sshd hardening. Other cookbooks
+# assume munchbox_base has already converged.
 # -------------------------------------------------------------------------------
 
-name             'munchbox_lib'
+name             'munchbox_base'
 maintainer       'Alex Freidah'
 maintainer_email 'alex.freidah@gmail.com'
 license          'MIT'
-description      'Shared helper library for Munchbox cookbooks'
-version          '0.2.0'
+description      'OS-level prerequisites every Munchbox node needs'
+version          '0.1.0'
 chef_version     '>= 17'
 issues_url       'https://github.com/afreidah/munchbox/issues'
 source_url       'https://github.com/afreidah/munchbox'
+
+depends 'munchbox_lib'
+
+supports 'debian'
+supports 'ubuntu'

--- a/infrastructure/cinc/cookbooks/munchbox_base/recipes/apt_repo.rb
+++ b/infrastructure/cinc/cookbooks/munchbox_base/recipes/apt_repo.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+# -------------------------------------------------------------------------------
+# Cookbook:: munchbox_base
+# Recipe:: apt_repo
+#
+# Registers the munchbox aptly repository + signing key on the node.
+# -------------------------------------------------------------------------------
+
+munchbox_base_apt_repo node[cookbook]['apt_repo']['name'] do
+  uri          node[cookbook]['apt_repo']['uri']
+  distribution node[cookbook]['apt_repo']['distribution']
+  components   node[cookbook]['apt_repo']['components']
+  key_url      node[cookbook]['apt_repo']['key_url']
+end

--- a/infrastructure/cinc/cookbooks/munchbox_base/recipes/default.rb
+++ b/infrastructure/cinc/cookbooks/munchbox_base/recipes/default.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+# -------------------------------------------------------------------------------
+# Cookbook:: munchbox_base
+# Recipe:: default
+#
+# Intentionally empty. Consumers cherry-pick the sub-recipes they need so this
+# cookbook can be depended on for its resources without forcing every concern
+# to converge. See README for the available sub-recipes.
+# -------------------------------------------------------------------------------

--- a/infrastructure/cinc/cookbooks/munchbox_base/recipes/journald.rb
+++ b/infrastructure/cinc/cookbooks/munchbox_base/recipes/journald.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+# -------------------------------------------------------------------------------
+# Cookbook:: munchbox_base
+# Recipe:: journald
+#
+# Applies journald disk/retention limits from node attributes via a
+# /etc/systemd/journald.conf.d drop-in.
+# -------------------------------------------------------------------------------
+
+munchbox_base_journald 'baseline' do
+  settings node[cookbook]['journald'].to_hash
+end

--- a/infrastructure/cinc/cookbooks/munchbox_base/recipes/packages.rb
+++ b/infrastructure/cinc/cookbooks/munchbox_base/recipes/packages.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+# -------------------------------------------------------------------------------
+# Cookbook:: munchbox_base
+# Recipe:: packages
+#
+# Installs the baseline apt package set every Munchbox node depends on.
+# -------------------------------------------------------------------------------
+
+munchbox_base_packages 'baseline' do
+  packages node[cookbook]['packages']
+end

--- a/infrastructure/cinc/cookbooks/munchbox_base/recipes/sshd.rb
+++ b/infrastructure/cinc/cookbooks/munchbox_base/recipes/sshd.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+# -------------------------------------------------------------------------------
+# Cookbook:: munchbox_base
+# Recipe:: sshd
+#
+# Applies sshd hardening from node attributes by templating
+# /etc/ssh/sshd_config end-to-end. Restarts sshd when the config changes.
+# -------------------------------------------------------------------------------
+
+munchbox_base_sshd 'baseline' do
+  settings node[cookbook]['ssh'].to_hash
+end

--- a/infrastructure/cinc/cookbooks/munchbox_base/recipes/timesync.rb
+++ b/infrastructure/cinc/cookbooks/munchbox_base/recipes/timesync.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+# -------------------------------------------------------------------------------
+# Cookbook:: munchbox_base
+# Recipe:: timesync
+#
+# Configures systemd-timesyncd against the NTP servers in node attributes
+# and ensures the service is enabled+running.
+# -------------------------------------------------------------------------------
+
+munchbox_base_timesync 'baseline' do
+  service          node[cookbook]['timesync']['service']
+  ntp_servers      node[cookbook]['timesync']['ntp_servers']
+  fallback_servers node[cookbook]['timesync']['fallback_servers']
+end

--- a/infrastructure/cinc/cookbooks/munchbox_base/resources/munchbox_base_apt_repo.rb
+++ b/infrastructure/cinc/cookbooks/munchbox_base/resources/munchbox_base_apt_repo.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+# -------------------------------------------------------------------------------
+# Cookbook:: munchbox_base
+# Resource:: munchbox_base_apt_repo
+#
+# Registers an apt repository + signing key. Designed for the in-house aptly
+# repo at apt.munchbox.cc but takes uri/distribution/components/key_url so
+# any cookbook that needs another apt repo can reuse the resource.
+#
+# Properties:
+#   uri          - Base URL of the repo (required).
+#   distribution - Suite, e.g. 'stable'.
+#   components   - Array of components, e.g. %w(main).
+#   key_url      - URL of the ASCII-armoured signing key (optional but
+#                  effectively required for any modern repo).
+# -------------------------------------------------------------------------------
+
+unified_mode true
+
+provides :munchbox_base_apt_repo
+
+property :uri,          String, required: true
+property :distribution, String, default: 'stable'
+property :components,   Array,  default: %w(main)
+property :key_url,      String
+
+default_action :configure
+
+# --- Add the repo + key (apt_repository runs apt-get update internally) ---
+action :configure do
+  # Refresh the cache first -- stock cloud images often ship with an apt
+  # index pinned to a debian point release that has since rolled forward,
+  # so explicit version installs (gnupg, apt-transport-https) 404 against
+  # the live mirror until `apt-get update` runs. `:periodic` keeps this
+  # idempotent across converges (only refreshes if the cache is older
+  # than `frequency` seconds, default 1 day).
+  apt_update 'munchbox_base_apt_repo' do
+    action :periodic
+  end
+
+  # apt_repository shells out to `gpg` to verify the signing key + may need
+  # https transport for the apt_repository fetch. Ensure both are present
+  # before the repository resource runs.
+  package %w(gnupg apt-transport-https ca-certificates) do
+    action :install
+  end
+
+  apt_repository new_resource.name do
+    uri          new_resource.uri
+    distribution new_resource.distribution
+    components   new_resource.components
+    key          new_resource.key_url if new_resource.key_url
+    action       :add
+  end
+end
+
+# --- Remove the repo from sources.list.d ---
+action :remove do
+  apt_repository new_resource.name do
+    action :remove
+  end
+end

--- a/infrastructure/cinc/cookbooks/munchbox_base/resources/munchbox_base_journald.rb
+++ b/infrastructure/cinc/cookbooks/munchbox_base/resources/munchbox_base_journald.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+# -------------------------------------------------------------------------------
+# Cookbook:: munchbox_base
+# Resource:: munchbox_base_journald
+#
+# Renders a journald.conf.d drop-in to bound on-disk log size and retention,
+# ensures journald is enabled+running, and restarts it when the drop-in
+# changes.
+#
+# Properties:
+#   settings - Hash of snake_case keys -> values. Keys are rendered as
+#              PascalCase directives in [Journal] (e.g. system_max_use ->
+#              SystemMaxUse). nil values are skipped.
+# -------------------------------------------------------------------------------
+
+unified_mode true
+
+provides :munchbox_base_journald
+
+property :settings, Hash, required: true
+
+default_action :configure
+
+# --- Drop conf.d override, enable+start journald, restart on change ---
+action :configure do
+  directory '/etc/systemd/journald.conf.d' do
+    owner 'root'
+    group 'root'
+    mode  '0755'
+    recursive true
+  end
+
+  template '/etc/systemd/journald.conf.d/00-munchbox.conf' do
+    source 'journald.conf.erb'
+    owner  'root'
+    group  'root'
+    mode   '0644'
+    variables(settings: new_resource.settings)
+    notifies :restart, 'service[systemd-journald]', :delayed
+  end
+
+  service 'systemd-journald' do
+    action %i(enable start)
+  end
+end
+
+# --- Remove the drop-in; restart journald so it picks up upstream defaults ---
+action :remove do
+  file '/etc/systemd/journald.conf.d/00-munchbox.conf' do
+    action :delete
+    notifies :restart, 'service[systemd-journald]', :delayed
+  end
+
+  service 'systemd-journald' do
+    action %i(enable start)
+  end
+end

--- a/infrastructure/cinc/cookbooks/munchbox_base/resources/munchbox_base_packages.rb
+++ b/infrastructure/cinc/cookbooks/munchbox_base/resources/munchbox_base_packages.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+# -------------------------------------------------------------------------------
+# Cookbook:: munchbox_base
+# Resource:: munchbox_base_packages
+#
+# Installs (or removes) a set of apt packages. Used by the recipe to ship the
+# baseline package set every node needs; also reusable from other cookbooks
+# that want to declare their own package list against the same resource.
+#
+# Properties:
+#   packages - Array of package names (required).
+# -------------------------------------------------------------------------------
+
+unified_mode true
+
+provides :munchbox_base_packages
+
+property :packages, Array, required: true
+
+default_action :install
+
+# --- Ensure every named package is installed ---
+action :install do
+  package new_resource.name do
+    package_name new_resource.packages
+    action       :install
+  end
+end
+
+# --- Purge every named package (use with care) ---
+action :remove do
+  package new_resource.name do
+    package_name new_resource.packages
+    action       :remove
+  end
+end

--- a/infrastructure/cinc/cookbooks/munchbox_base/resources/munchbox_base_sshd.rb
+++ b/infrastructure/cinc/cookbooks/munchbox_base/resources/munchbox_base_sshd.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+# -------------------------------------------------------------------------------
+# Cookbook:: munchbox_base
+# Resource:: munchbox_base_sshd
+#
+# Owns /etc/ssh/sshd_config end-to-end. The file is fully templated so we
+# don't have to fight first-occurrence-wins precedence against whatever the
+# upstream package or base image dropped in. Ensures sshd is enabled +
+# running and restarts it whenever the config changes.
+#
+# Properties:
+#   settings - Hash of snake_case keys -> values. Keys are rendered as
+#              PascalCase sshd directives (e.g. permit_root_login ->
+#              PermitRootLogin). nil values are skipped.
+# -------------------------------------------------------------------------------
+
+unified_mode true
+
+provides :munchbox_base_sshd
+
+property :settings, Hash, required: true
+
+default_action :configure
+
+# --- Template the whole sshd_config, enable+start sshd, restart on change ---
+action :configure do
+  template '/etc/ssh/sshd_config' do
+    source 'sshd_config.erb'
+    owner  'root'
+    group  'root'
+    mode   '0644'
+    variables(settings: new_resource.settings)
+    notifies :restart, 'service[ssh]', :delayed
+  end
+
+  service 'ssh' do
+    action %i(enable start)
+  end
+end

--- a/infrastructure/cinc/cookbooks/munchbox_base/resources/munchbox_base_timesync.rb
+++ b/infrastructure/cinc/cookbooks/munchbox_base/resources/munchbox_base_timesync.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+# -------------------------------------------------------------------------------
+# Cookbook:: munchbox_base
+# Resource:: munchbox_base_timesync
+#
+# Configures systemd-timesyncd via a conf.d drop-in and ensures the timesync
+# service is enabled+running. Pure function of its properties.
+#
+# Properties:
+#   service          - systemd unit to enable (default systemd-timesyncd).
+#   ntp_servers      - Array of primary NTP servers (required).
+#   fallback_servers - Array of fallback NTP servers (optional).
+# -------------------------------------------------------------------------------
+
+unified_mode true
+
+provides :munchbox_base_timesync
+
+property :service,          String, default: 'systemd-timesyncd'
+property :ntp_servers,      Array,  required: true
+property :fallback_servers, Array,  default: []
+
+default_action :configure
+
+# --- Drop conf.d override, enable+start service, restart on change ---
+action :configure do
+  directory '/etc/systemd/timesyncd.conf.d' do
+    owner 'root'
+    group 'root'
+    mode  '0755'
+    recursive true
+  end
+
+  template '/etc/systemd/timesyncd.conf.d/00-munchbox.conf' do
+    source 'timesyncd.conf.erb'
+    owner  'root'
+    group  'root'
+    mode   '0644'
+    variables(
+      ntp_servers: new_resource.ntp_servers,
+      fallback_servers: new_resource.fallback_servers
+    )
+    notifies :restart, "service[#{new_resource.service}]", :delayed
+  end
+
+  service new_resource.service do
+    action %i(enable start)
+  end
+end
+
+# --- Remove the drop-in but leave the service running ---
+action :remove do
+  file '/etc/systemd/timesyncd.conf.d/00-munchbox.conf' do
+    action :delete
+    notifies :restart, "service[#{new_resource.service}]", :delayed
+  end
+
+  service new_resource.service do
+    action %i(enable start)
+  end
+end

--- a/infrastructure/cinc/cookbooks/munchbox_base/spec/recipes/apt_repo_spec.rb
+++ b/infrastructure/cinc/cookbooks/munchbox_base/spec/recipes/apt_repo_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+# -------------------------------------------------------------------------------
+# apt_repo recipe spec
+#
+# Step into the wrapping resource so we also cover the underlying
+# apt_repository chef resource it declares.
+# -------------------------------------------------------------------------------
+
+RSpec.describe 'munchbox_base::apt_repo' do
+  cached(:chef_run) do
+    ChefSpec::SoloRunner.new(step_into: %w(munchbox_base_apt_repo)).converge('munchbox_base::apt_repo')
+  end
+
+  # --- Declares the wrapping resource keyed by the configured repo name ---
+  it 'declares the munchbox apt_repo resource' do
+    expect(chef_run).to configure_munchbox_base_apt_repo('munchbox')
+      .with(uri: 'https://apt.munchbox.cc', distribution: 'stable')
+  end
+
+  # --- Underlying apt_repository gets added with our uri + suite ---
+  it 'adds the apt_repository' do
+    expect(chef_run).to add_apt_repository('munchbox')
+      .with(uri: 'https://apt.munchbox.cc', distribution: 'stable')
+  end
+end

--- a/infrastructure/cinc/cookbooks/munchbox_base/spec/recipes/default_spec.rb
+++ b/infrastructure/cinc/cookbooks/munchbox_base/spec/recipes/default_spec.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+# -------------------------------------------------------------------------------
+# Default recipe spec
+#
+# The default recipe is intentionally empty -- consumers cherry-pick the
+# sub-recipes they need. This spec just asserts a clean converge with no
+# resources declared, so the empty-recipe contract is enforced.
+# -------------------------------------------------------------------------------
+
+RSpec.describe 'munchbox_base::default' do
+  let(:chef_run) { ChefSpec::SoloRunner.new.converge('munchbox_base::default') }
+
+  it 'converges without declaring any resources' do
+    expect(chef_run.resource_collection.to_a).to be_empty
+  end
+end

--- a/infrastructure/cinc/cookbooks/munchbox_base/spec/recipes/journald_spec.rb
+++ b/infrastructure/cinc/cookbooks/munchbox_base/spec/recipes/journald_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+# -------------------------------------------------------------------------------
+# journald recipe spec
+# -------------------------------------------------------------------------------
+
+RSpec.describe 'munchbox_base::journald' do
+  cached(:chef_run) do
+    ChefSpec::SoloRunner.new(step_into: %w(munchbox_base_journald)).converge('munchbox_base::journald')
+  end
+
+  # --- Wrapping resource gets credit for coverage ---
+  it 'declares the journald wrapping resource' do
+    expect(chef_run).to configure_munchbox_base_journald('baseline')
+  end
+
+  # --- conf.d directory + drop-in get created with correct perms ---
+  it 'creates the journald conf.d directory' do
+    expect(chef_run).to create_directory('/etc/systemd/journald.conf.d')
+      .with(owner: 'root', group: 'root', mode: '0755')
+  end
+
+  it 'renders the journald drop-in' do
+    expect(chef_run).to create_template('/etc/systemd/journald.conf.d/00-munchbox.conf')
+  end
+
+  # --- Service is enabled + started, restart fires on drop-in change ---
+  it 'enables and starts systemd-journald' do
+    expect(chef_run).to enable_service('systemd-journald')
+    expect(chef_run).to start_service('systemd-journald')
+  end
+
+  it 'queues a delayed restart when the drop-in changes' do
+    template = chef_run.template('/etc/systemd/journald.conf.d/00-munchbox.conf')
+    expect(template).to notify('service[systemd-journald]').to(:restart).delayed
+  end
+end

--- a/infrastructure/cinc/cookbooks/munchbox_base/spec/recipes/packages_spec.rb
+++ b/infrastructure/cinc/cookbooks/munchbox_base/spec/recipes/packages_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+# -------------------------------------------------------------------------------
+# packages recipe spec
+# -------------------------------------------------------------------------------
+
+RSpec.describe 'munchbox_base::packages' do
+  cached(:chef_run) do
+    ChefSpec::SoloRunner.new(step_into: %w(munchbox_base_packages)) do |node|
+      node.override['munchbox_base']['packages'] = %w(curl jq vim)
+    end.converge('munchbox_base::packages')
+  end
+
+  # --- Wrapping resource gets credit for coverage + carries the package list ---
+  it 'declares the baseline packages resource with the configured list' do
+    expect(chef_run).to install_munchbox_base_packages('baseline')
+      .with(packages: %w(curl jq vim))
+  end
+
+  # --- Underlying package resource installs every requested package ---
+  it 'installs every requested package' do
+    expect(chef_run).to install_package('baseline')
+      .with(package_name: %w(curl jq vim))
+  end
+end

--- a/infrastructure/cinc/cookbooks/munchbox_base/spec/recipes/sshd_spec.rb
+++ b/infrastructure/cinc/cookbooks/munchbox_base/spec/recipes/sshd_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+# -------------------------------------------------------------------------------
+# sshd recipe spec
+# -------------------------------------------------------------------------------
+
+RSpec.describe 'munchbox_base::sshd' do
+  cached(:chef_run) do
+    ChefSpec::SoloRunner.new(step_into: %w(munchbox_base_sshd)).converge('munchbox_base::sshd')
+  end
+
+  # --- Wrapping resource gets credit for coverage ---
+  it 'declares the sshd wrapping resource' do
+    expect(chef_run).to configure_munchbox_base_sshd('baseline')
+  end
+
+  # --- sshd_config is templated end-to-end with correct perms ---
+  it 'templates /etc/ssh/sshd_config' do
+    expect(chef_run).to create_template('/etc/ssh/sshd_config')
+      .with(owner: 'root', group: 'root', mode: '0644')
+  end
+
+  # --- Service is enabled + started, restart fires on config change ---
+  it 'enables and starts ssh' do
+    expect(chef_run).to enable_service('ssh')
+    expect(chef_run).to start_service('ssh')
+  end
+
+  it 'queues a delayed restart when sshd_config changes' do
+    template = chef_run.template('/etc/ssh/sshd_config')
+    expect(template).to notify('service[ssh]').to(:restart).delayed
+  end
+end

--- a/infrastructure/cinc/cookbooks/munchbox_base/spec/recipes/timesync_spec.rb
+++ b/infrastructure/cinc/cookbooks/munchbox_base/spec/recipes/timesync_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+# -------------------------------------------------------------------------------
+# timesync recipe spec
+# -------------------------------------------------------------------------------
+
+RSpec.describe 'munchbox_base::timesync' do
+  cached(:chef_run) do
+    ChefSpec::SoloRunner.new(step_into: %w(munchbox_base_timesync)).converge('munchbox_base::timesync')
+  end
+
+  # --- Wrapping resource gets credit for coverage ---
+  it 'declares the timesync wrapping resource' do
+    expect(chef_run).to configure_munchbox_base_timesync('baseline')
+  end
+
+  # --- conf.d directory + drop-in get created with correct perms ---
+  it 'creates the timesyncd conf.d directory' do
+    expect(chef_run).to create_directory('/etc/systemd/timesyncd.conf.d')
+      .with(owner: 'root', group: 'root', mode: '0755')
+  end
+
+  it 'renders the timesyncd drop-in' do
+    expect(chef_run).to create_template('/etc/systemd/timesyncd.conf.d/00-munchbox.conf')
+  end
+
+  # --- Service is enabled + started, restart fires on drop-in change ---
+  it 'enables and starts the timesync service' do
+    expect(chef_run).to enable_service('systemd-timesyncd')
+    expect(chef_run).to start_service('systemd-timesyncd')
+  end
+
+  it 'queues a delayed restart when the drop-in changes' do
+    template = chef_run.template('/etc/systemd/timesyncd.conf.d/00-munchbox.conf')
+    expect(template).to notify('service[systemd-timesyncd]').to(:restart).delayed
+  end
+end

--- a/infrastructure/cinc/cookbooks/munchbox_base/spec/spec_helper.rb
+++ b/infrastructure/cinc/cookbooks/munchbox_base/spec/spec_helper.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+# -------------------------------------------------------------------------------
+# Cookbook:: munchbox_base
+# Spec helper -- wires up chefspec with our cookbook path so the `cookbook`
+# helper from munchbox_lib resolves correctly when recipes and resources run.
+# -------------------------------------------------------------------------------
+
+require 'chefspec'
+
+# --- Load shared rspec/chefspec matchers (e.g. do_nothing) ---
+Dir[File.expand_path('support/**/*.rb', __dir__)].each { |f| require f }
+
+ChefSpec::Coverage.start! { add_filter 'munchbox_lib' }
+
+RSpec.configure do |config|
+  # --- Point chefspec at this cookbook + munchbox_lib next door ---
+  config.cookbook_path = [
+    File.expand_path('../../', __dir__),
+    File.expand_path('../../../munchbox_lib', __dir__),
+  ]
+
+  config.platform        = 'debian'
+  config.version         = '12'
+  config.log_level       = :error
+  config.disable_monkey_patching!
+  config.order = :random
+  Kernel.srand(config.seed)
+end

--- a/infrastructure/cinc/cookbooks/munchbox_base/spec/support/matchers.rb
+++ b/infrastructure/cinc/cookbooks/munchbox_base/spec/support/matchers.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+# -------------------------------------------------------------------------------
+# Custom rspec/chefspec matchers
+#
+# ChefSpec's auto-generated matchers (install_package, enable_service, ...)
+# call `ChefSpec::Coverage.cover!` on the resource, which is how the coverage
+# tracker decides a resource was tested. Resources declared with `action
+# :nothing` (services declared for notifies, apt_update subscribed to a repo)
+# never get hit by an action-named matcher, so they always show up as
+# untouched.
+#
+# `do_nothing` here is a thin matcher that calls cover! and then asserts the
+# resource's action is :nothing. Use it on the chef_run resource accessor:
+#
+#   expect(chef_run.service('ssh')).to do_nothing
+#   expect(chef_run.apt_update('munchbox-apt-update')).to do_nothing
+# -------------------------------------------------------------------------------
+
+RSpec::Matchers.define :do_nothing do
+  match do |resource|
+    next false unless resource
+
+    ChefSpec::Coverage.cover!(resource)
+    actions = Array(resource.action)
+    actions.include?(:nothing)
+  end
+
+  failure_message do |resource|
+    if resource.nil?
+      'expected a chef resource but got nil'
+    else
+      "expected #{resource} to have action :nothing, got #{Array(resource.action).inspect}"
+    end
+  end
+end

--- a/infrastructure/cinc/cookbooks/munchbox_base/templates/journald.conf.erb
+++ b/infrastructure/cinc/cookbooks/munchbox_base/templates/journald.conf.erb
@@ -1,0 +1,11 @@
+<%#
+  Cookbook:: munchbox_base
+  Template:: journald.conf.erb
+  Dropped at /etc/systemd/journald.conf.d/00-munchbox.conf. Only renders
+  keys that are present in the settings hash; pass `nil` to skip a setting.
+%>
+[Journal]
+<% @settings.each do |key, value| -%>
+<%   next if value.nil? -%>
+<%= key.split('_').map(&:capitalize).join %>=<%= value %>
+<% end -%>

--- a/infrastructure/cinc/cookbooks/munchbox_base/templates/sshd_config.erb
+++ b/infrastructure/cinc/cookbooks/munchbox_base/templates/sshd_config.erb
@@ -1,0 +1,39 @@
+<%#
+  Cookbook:: munchbox_base
+  Template:: sshd_config.erb
+
+  Full /etc/ssh/sshd_config. Owned end-to-end by munchbox_base::sshd so we
+  don't have to fight sshd's first-occurrence-wins precedence against the
+  upstream package config. Tunable hardening flows in via @settings (keys
+  are snake_case in the hash and rendered as PascalCase directives).
+%>
+# Managed by chef (munchbox_base::sshd) -- do not edit by hand.
+
+# --- Listen settings ---
+Port 22
+AddressFamily any
+ListenAddress 0.0.0.0
+ListenAddress ::
+
+# --- Host keys (debian defaults) ---
+HostKey /etc/ssh/ssh_host_rsa_key
+HostKey /etc/ssh/ssh_host_ecdsa_key
+HostKey /etc/ssh/ssh_host_ed25519_key
+
+# --- Tunable hardening (from node attributes) ---
+<% @settings.each do |key, value| -%>
+<%   next if value.nil? -%>
+<%= key.to_s.split('_').map(&:capitalize).join %> <%= value %>
+<% end -%>
+
+# --- Auth plumbing ---
+AuthorizedKeysFile .ssh/authorized_keys
+UsePAM yes
+PrintMotd no
+AcceptEnv LANG LC_*
+
+# --- Subsystems ---
+Subsystem sftp /usr/lib/openssh/sftp-server
+
+# --- Drop-ins from packages (kept last so they can't shadow our hardening) ---
+Include /etc/ssh/sshd_config.d/*.conf

--- a/infrastructure/cinc/cookbooks/munchbox_base/templates/timesyncd.conf.erb
+++ b/infrastructure/cinc/cookbooks/munchbox_base/templates/timesyncd.conf.erb
@@ -1,0 +1,10 @@
+<%#
+  Cookbook:: munchbox_base
+  Template:: timesyncd.conf.erb
+  Dropped at /etc/systemd/timesyncd.conf.d/00-munchbox.conf.
+%>
+[Time]
+NTP=<%= @ntp_servers.join(' ') %>
+<% unless @fallback_servers.empty? -%>
+FallbackNTP=<%= @fallback_servers.join(' ') %>
+<% end -%>

--- a/infrastructure/cinc/cookbooks/munchbox_base/test/integration/default/controls/munchbox_base.rb
+++ b/infrastructure/cinc/cookbooks/munchbox_base/test/integration/default/controls/munchbox_base.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+# -------------------------------------------------------------------------------
+# munchbox_base integration controls
+#
+# One control per recipe. Each asserts: the file(s) the resource was supposed
+# to create are on disk with our marker, and the corresponding systemd unit
+# is enabled+running.
+# -------------------------------------------------------------------------------
+
+control 'apt_repo' do
+  impact 1.0
+  title 'munchbox_base::apt_repo registers a working apt repo'
+
+  describe file('/etc/apt/sources.list.d/nginx.list') do
+    it { should exist }
+    its('content') { should match(%r{nginx\.org/packages/debian}) }
+  end
+end
+
+control 'packages' do
+  impact 1.0
+  title 'munchbox_base::packages installs the baseline package set'
+
+  %w(curl jq).each do |pkg|
+    describe package(pkg) do
+      it { should be_installed }
+    end
+  end
+end
+
+control 'timesync' do
+  impact 1.0
+  title 'munchbox_base::timesync drops conf.d override and runs the service'
+
+  describe file('/etc/systemd/timesyncd.conf.d/00-munchbox.conf') do
+    it { should exist }
+    its('mode') { should cmp '0644' }
+    its('content') { should match(/^NTP=.*pool\.ntp\.org/) }
+  end
+
+  describe service('systemd-timesyncd') do
+    it { should be_installed }
+    it { should be_enabled }
+    it { should be_running }
+  end
+end
+
+control 'journald' do
+  impact 1.0
+  title 'munchbox_base::journald drops conf.d override and runs the service'
+
+  describe file('/etc/systemd/journald.conf.d/00-munchbox.conf') do
+    it { should exist }
+    its('mode') { should cmp '0644' }
+    its('content') { should match(/^SystemMaxUse=2G/) }
+    its('content') { should match(/^MaxRetentionSec=2week/) }
+  end
+
+  describe service('systemd-journald') do
+    it { should be_enabled }
+    it { should be_running }
+  end
+end
+
+control 'sshd' do
+  impact 1.0
+  title 'munchbox_base::sshd templates sshd_config and runs the service'
+
+  describe file('/etc/ssh/sshd_config') do
+    it { should exist }
+    its('mode') { should cmp '0644' }
+    its('content') { should match(/^PermitRootLogin prohibit-password/) }
+    its('content') { should match(/^PasswordAuthentication no/) }
+  end
+
+  describe service('ssh') do
+    it { should be_enabled }
+    it { should be_running }
+  end
+end

--- a/infrastructure/cinc/cookbooks/munchbox_base/test/integration/default/inspec.yml
+++ b/infrastructure/cinc/cookbooks/munchbox_base/test/integration/default/inspec.yml
@@ -1,0 +1,10 @@
+---
+name: munchbox_base
+title: munchbox_base integration controls
+maintainer: Alex Freidah
+copyright: Alex Freidah
+license: MIT
+summary: Validates a converged munchbox_base node (apt repo, packages, timesync, journald, sshd).
+version: 0.1.0
+supports:
+  - platform: debian

--- a/infrastructure/cinc/cookbooks/munchbox_lib/README.md
+++ b/infrastructure/cinc/cookbooks/munchbox_lib/README.md
@@ -16,9 +16,14 @@ depends 'munchbox_lib'
 Returns the calling cookbook's name by parsing its own `metadata.rb`. Lets
 the literal cookbook name live in exactly one place per cookbook.
 
-Available as a bare method inside recipes and resources:
+Available as a bare method everywhere: recipes, resources, templates, AND
+attribute files (chef >= 12 loads libraries before attributes, and `Chef::Node`
+is extended so the bare `cookbook` method resolves inside attribute files too).
 
 ```ruby
+# attributes/default.rb
+default[cookbook]['svc_user'] = 'alice'
+
 # recipes/server.rb
 user node[cookbook]['svc_user'] do
   action :create
@@ -34,11 +39,6 @@ MunchboxLibCookbook::Helpers.cookbook
 Results are memoized for the chef-client run lifetime — the first call walks
 the directory tree to find `metadata.rb` and parses it; every subsequent call
 from the same file is a hash lookup.
-
-**Caveat:** chef evaluates attribute files before libraries, so this helper
-is **not** available inside `attributes/*.rb`. Attribute files need to declare
-a local `cookbook = '<name>'` at the top, matching `metadata.rb` by hand.
-Every other context (recipes, resources, templates) gets it for free.
 
 ## Development
 

--- a/infrastructure/cinc/cookbooks/munchbox_lib/libraries/cookbook_helpers.rb
+++ b/infrastructure/cinc/cookbooks/munchbox_lib/libraries/cookbook_helpers.rb
@@ -12,10 +12,9 @@
 # .cookbook` and as a bare `cookbook` method inside recipes and resources
 # (via the DSL extension at the bottom of this file).
 #
-# Caveat: chef evaluates attribute files before libraries, so this helper is
-# NOT available in `attributes/*.rb`. Attribute files need to declare a local
-# `cookbook = '<name>'` at the top, matching `metadata.rb` by hand. Every
-# other context (recipes, resources, templates) gets it for free.
+# Available everywhere: recipes, resources, templates, AND attribute files
+# (chef >= 12 loads libraries before attributes, and we extend Chef::Node so
+# the bare `cookbook` method resolves inside attribute files too).
 # -------------------------------------------------------------------------------
 
 module MunchboxLibCookbook
@@ -78,9 +77,13 @@ end
 # -------------------------------------------------------------------------------
 # DSL extension
 #
-# Make `cookbook` available as a bare method inside recipes and resources.
-# Wrapping it in a module so we pass the *caller's* file path through;
-# otherwise the default would always resolve to this file.
+# Make `cookbook` available as a bare method inside recipes, resources, and
+# attribute files. Wrapping it in a module so we pass the *caller's* file path
+# through; otherwise the default would always resolve to this file.
+#
+# Note: on chef >= 12 libraries are loaded before attributes, so extending
+# Chef::Node here lets attribute files call `cookbook` directly without having
+# to declare the name as a local literal.
 # -------------------------------------------------------------------------------
 
 dsl_extension = Module.new do
@@ -92,3 +95,4 @@ end
 
 Chef::DSL::Recipe.include(dsl_extension)
 Chef::Resource.include(dsl_extension)
+Chef::Node.include(dsl_extension)

--- a/infrastructure/cinc/cookbooks/munchbox_lib/spec/libraries/cookbook_helpers_spec.rb
+++ b/infrastructure/cinc/cookbooks/munchbox_lib/spec/libraries/cookbook_helpers_spec.rb
@@ -108,3 +108,28 @@ RSpec.describe MunchboxLibCookbook::Helpers do
     end
   end
 end
+
+# -------------------------------------------------------------------------------
+# DSL extension
+#
+# The bare `cookbook` method must be included on Chef::DSL::Recipe,
+# Chef::Resource, and Chef::Node so recipes, resources, and attribute files
+# can all call it without naming the module.
+# -------------------------------------------------------------------------------
+
+RSpec.describe 'DSL extension' do
+  # --- Recipe DSL gets the bare method ---
+  it 'extends Chef::DSL::Recipe with a `cookbook` instance method' do
+    expect(Chef::DSL::Recipe.instance_method(:cookbook)).to be_a(UnboundMethod)
+  end
+
+  # --- Resource DSL gets the bare method ---
+  it 'extends Chef::Resource with a `cookbook` instance method' do
+    expect(Chef::Resource.instance_method(:cookbook)).to be_a(UnboundMethod)
+  end
+
+  # --- Attribute-file context (Chef::Node) gets the bare method ---
+  it 'extends Chef::Node with a `cookbook` instance method' do
+    expect(Chef::Node.instance_method(:cookbook)).to be_a(UnboundMethod)
+  end
+end

--- a/infrastructure/cinc/cookbooks/munchbox_lib/spec/spec_helper.rb
+++ b/infrastructure/cinc/cookbooks/munchbox_lib/spec/spec_helper.rb
@@ -14,6 +14,7 @@ module Chef; end unless defined?(Chef)
 module Chef::DSL; end unless defined?(Chef::DSL)
 module Chef::DSL::Recipe; end unless defined?(Chef::DSL::Recipe)
 class Chef::Resource; end unless defined?(Chef::Resource)
+class Chef::Node; end unless defined?(Chef::Node)
 
 require_relative '../libraries/cookbook_helpers'
 

--- a/infrastructure/cinc/scripts/kitchen/debian.sh
+++ b/infrastructure/cinc/scripts/kitchen/debian.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# -------------------------------------------------------------------------------
+# Munchbox cinc toolchain setup (Debian/Ubuntu)
+#
+# Installs cinc-workstation (chef + kitchen + inspec + cookstyle + chefspec
+# all bundled) and the libvirt/KVM/vagrant stack needed to run Kitchen VMs.
+# Idempotent -- re-running only installs what's missing.
+#
+# After this runs, every cookbook in infrastructure/cinc/cookbooks/ can use
+# bare `kitchen` / `chef` / `cookstyle` / `inspec` from PATH; wrappers in
+# /usr/local/bin do `env -i` so RVM / rbenv / bundler env can't pollute the
+# cinc-workstation embedded ruby.
+# -------------------------------------------------------------------------------
+
+set -euo pipefail
+
+# --- Install cinc-workstation if missing ---
+if [[ ! -x /opt/cinc-workstation/bin/kitchen ]]; then
+  echo "==> Installing cinc-workstation..."
+  curl -L https://omnitruck.cinc.sh/install.sh | sudo bash -s -- -P cinc-workstation
+fi
+
+# --- Install env-isolating wrappers in /usr/local/bin ---
+echo "==> Installing cinc-workstation wrappers to /usr/local/bin..."
+WRAPPER=/usr/local/bin/_cinc-wrapper
+sudo tee "$WRAPPER" >/dev/null <<'WRAPPER_EOF'
+#!/usr/bin/env bash
+# Runs a cinc-workstation binary with a clean env so RVM/rbenv/bundler
+# settings from the calling shell can't pollute gem resolution.
+set -e
+tool=$(basename "$0")
+exec env -i HOME="$HOME" TERM="${TERM:-xterm}" \
+  PATH=/opt/cinc-workstation/bin:/usr/local/bin:/usr/bin:/bin \
+  "/opt/cinc-workstation/bin/$tool" "$@"
+WRAPPER_EOF
+sudo chmod +x "$WRAPPER"
+
+for tool in kitchen chef cookstyle inspec cinc-auditor cinc berks knife ohai rspec; do
+  [[ -x "/opt/cinc-workstation/bin/$tool" ]] || continue
+  sudo ln -sf "$WRAPPER" "/usr/local/bin/$tool"
+done
+
+# --- Install KVM/libvirt + vagrant + vagrant-libvirt ---
+pkgs=(qemu-kvm libvirt-daemon-system libvirt-clients ebtables dnsmasq-base
+      bridge-utils vagrant vagrant-libvirt)
+if ! dpkg -s "${pkgs[@]}" >/dev/null 2>&1; then
+  echo "==> Installing KVM + libvirt + vagrant-libvirt..."
+  sudo apt-get update
+  sudo apt-get install -y "${pkgs[@]}"
+fi
+
+# --- Add the calling user to libvirt + kvm groups ---
+if ! id -nG "$USER" | grep -qw libvirt; then
+  echo "==> Adding $USER to libvirt + kvm groups (log out/in to take effect)"
+  sudo usermod -aG libvirt,kvm "$USER"
+fi
+
+echo ""
+echo "Kitchen toolchain ready."
+echo "If the wrappers aren't in PATH, open a new shell."


### PR DESCRIPTION
## Summary
- Adds the wide-base cookbook every Munchbox node will run: apt repo registration, baseline packages, systemd-timesyncd, journald limits, sshd hardening.
- One targeted custom resource + one recipe per concern; default recipe stays empty per the style guide.
- Tested end-to-end with test-kitchen + vagrant-libvirt (debian-12) and inspec; cookstyle + chefspec on every resource and recipe.
- Folds in a munchbox_lib bump to 0.2.0 — the `cookbook` helper now extends `Chef::Node` so it resolves in attribute files (needed by `munchbox_base/attributes/default.rb`).

## Test plan
- [x] `make lint` (cookstyle)
- [x] `make test` (chefspec)
- [x] `make kitchen` (kitchen create + converge + 2nd converge for idempotency + verify) on debian-12

Closes #85