### PR TITLE
GH_ISSUE_87: add cinc_server cookbook

### DIFF
--- a/infrastructure/cinc/cookbooks/cinc_server/.gitignore
+++ b/infrastructure/cinc/cookbooks/cinc_server/.gitignore
@@ -1,0 +1,12 @@
+# --- Test-kitchen state (per-VM logs, vagrant artifacts) ---
+.kitchen/
+kitchen.local.yml
+
+# --- Editor / language-server scratch ---
+.ruby-lsp/
+
+# --- Bundler vendor dir if installed locally ---
+vendor/bundle/
+
+# --- Berkshelf lock file (cookbook dep resolution result) ---
+Berksfile.lock

--- a/infrastructure/cinc/cookbooks/cinc_server/.rubocop.yml
+++ b/infrastructure/cinc/cookbooks/cinc_server/.rubocop.yml
@@ -1,0 +1,30 @@
+# -------------------------------------------------------------------------------
+# Cookstyle (rubocop) config for cinc_server.
+#
+# Inherits cookstyle defaults; project-specific overrides only.
+# -------------------------------------------------------------------------------
+
+require:
+  - cookstyle
+
+inherit_gem:
+  cookstyle: config/cookstyle.yml
+
+AllCops:
+  NewCops: enable
+  TargetRubyVersion: 3.1
+  Exclude:
+    - 'Berksfile.lock'
+    - 'Gemfile.lock'
+    - 'tmp/**/*'
+    - 'vendor/**/*'
+
+# --- Long top-of-file box comments are common; let them be ---
+Layout/LineLength:
+  Max: 120
+
+# --- Specs + inspec controls use long describe blocks; don't fight that ---
+Metrics/BlockLength:
+  Exclude:
+    - 'spec/**/*'
+    - 'test/**/*'

--- a/infrastructure/cinc/cookbooks/cinc_server/Berksfile
+++ b/infrastructure/cinc/cookbooks/cinc_server/Berksfile
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+# -------------------------------------------------------------------------------
+# Berksfile for cinc_server
+#
+# `source chef_repo: '../..'` points at infrastructure/cinc/ so berks finds
+# the sibling cookbooks/ directory (where munchbox_lib lives). `metadata`
+# pulls dep declarations from metadata.rb in this dir.
+# -------------------------------------------------------------------------------
+
+source chef_repo: '../..'
+
+metadata

--- a/infrastructure/cinc/cookbooks/cinc_server/Makefile
+++ b/infrastructure/cinc/cookbooks/cinc_server/Makefile
@@ -1,0 +1,63 @@
+# -------------------------------------------------------------------------------
+# Cookbook:: cinc_server
+# Makefile
+#
+# All targets delegate to cinc-workstation tools wrapped in /usr/local/bin
+# (which env -i to isolate from any RVM/bundler pollution). Bootstrap the
+# toolchain once with `make tools` -- after that everything just works.
+#
+#   make tools    - install cinc-workstation + libvirt/vagrant stack
+#   make lint     - cookstyle
+#   make test     - chefspec/rspec via chef's bundled rspec
+#   make kitchen  - full test-kitchen run (create + converge + verify + destroy)
+#   make verify   - kitchen verify only (VM already up)
+#   make destroy  - tear down the kitchen VM
+# -------------------------------------------------------------------------------
+
+# --- Absolute paths to the cinc wrappers so RVM/rbenv PATH ordering can't win ---
+CHEF      := /usr/local/bin/chef
+COOKSTYLE := /usr/local/bin/cookstyle
+KITCHEN   := /usr/local/bin/kitchen
+
+.PHONY: help tools test lint kitchen create converge verify login destroy
+
+help:
+	@echo "make tools     - install cinc-workstation + libvirt/vagrant stack (one-time host setup)"
+	@echo "make lint      - cookstyle (rubocop with chef cops)"
+	@echo "make test      - chefspec/rspec unit tests"
+	@echo ""
+	@echo "Kitchen lifecycle (run in order, or use 'make kitchen' to do all in one shot):"
+	@echo "  make create    - provision the VM (vagrant up)"
+	@echo "  make converge  - run cinc-client on the VM"
+	@echo "  make verify    - run inspec controls against the converged VM"
+	@echo "  make login     - ssh into the VM"
+	@echo "  make destroy   - tear the VM down"
+	@echo ""
+	@echo "  make kitchen   - create + converge + verify + destroy in one go"
+
+tools:
+	../../scripts/kitchen/debian.sh
+
+lint:
+	$(COOKSTYLE) .
+
+test:
+	$(CHEF) exec rspec spec/
+
+kitchen:
+	$(KITCHEN) test
+
+create:
+	$(KITCHEN) create
+
+converge:
+	$(KITCHEN) converge
+
+verify:
+	$(KITCHEN) verify
+
+login:
+	$(KITCHEN) login
+
+destroy:
+	$(KITCHEN) destroy

--- a/infrastructure/cinc/cookbooks/cinc_server/attributes/default.rb
+++ b/infrastructure/cinc/cookbooks/cinc_server/attributes/default.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+# -------------------------------------------------------------------------------
+# Cookbook:: cinc_server
+# Attributes:: default
+#
+# Defaults for the cinc_server cookbook. Every entry is keyed under the
+# cookbook's namespace via `node[cookbook]`, so renaming the cookbook is a
+# one-line change in metadata.rb.
+# -------------------------------------------------------------------------------
+
+# -------------------------------------------------------------------------------
+# cinc-server package
+#
+# cinc-server isn't published to a generic apt repo; the project ships .deb
+# artefacts at downloads.cinc.sh. Pin a known-good version per node so
+# upgrades are a deliberate attribute bump, not a silent moving target.
+# -------------------------------------------------------------------------------
+
+default[cookbook]['install'] = {
+  'version' => '15.10.91',
+  'url' => 'https://downloads.cinc.sh/files/stable/cinc-server/15.10.91/debian/12/cinc-server-core_15.10.91-1_amd64.deb',
+  'checksum' => nil,
+}
+
+# -------------------------------------------------------------------------------
+# chef-server.rb config
+#
+# `api_fqdn` is the one setting every install must override. Extra knobs go
+# into `settings` and are rendered verbatim into chef-server.rb (so values
+# need to be valid ruby literals -- quote strings, etc.).
+# -------------------------------------------------------------------------------
+
+default[cookbook]['config'] = {
+  'api_fqdn' => 'cinc-server.local',
+  'settings' => {
+    "nginx['enable_non_ssl']" => 'true',
+  },
+}

--- a/infrastructure/cinc/cookbooks/cinc_server/kitchen.yml
+++ b/infrastructure/cinc/cookbooks/cinc_server/kitchen.yml
@@ -1,0 +1,49 @@
+---
+# -------------------------------------------------------------------------------
+# Test-Kitchen config for cinc_server.
+#
+# cinc-server is a heavy install (~300 MB .deb, then `chef-server-ctl
+# reconfigure` brings up postgres + opscode-erchef + nginx etc). The VM
+# needs real memory or reconfigure OOMs partway through. Expect the full
+# `make kitchen` cycle to run ~10-15 minutes.
+# -------------------------------------------------------------------------------
+
+driver:
+  name: vagrant
+  provider: libvirt
+  customize:
+    memory: 4096
+    cpus: 2
+
+provisioner:
+  name: chef_zero
+  product_name: cinc
+  product_version: latest
+  install_strategy: once
+  multiple_converge: 2
+  enforce_idempotency: true
+  chef_license: accept
+  log_level: warn
+
+verifier:
+  name: inspec
+  format: doc
+
+platforms:
+  - name: debian-12
+    driver:
+      box: generic/debian12
+
+suites:
+  - name: default
+    run_list:
+      - recipe[cinc_server::install]
+      - recipe[cinc_server::configure]
+    attributes:
+      cinc_server:
+        config:
+          # api_fqdn must resolve from inside the VM for chef-server-ctl
+          # reconfigure to be happy. Use the box's default hostname.
+          api_fqdn: cinc-server.test
+          settings:
+            "nginx['enable_non_ssl']": 'true'

--- a/infrastructure/cinc/cookbooks/cinc_server/metadata.rb
+++ b/infrastructure/cinc/cookbooks/cinc_server/metadata.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+# -------------------------------------------------------------------------------
+# Cookbook:: cinc_server
+#
+# Project: Munchbox / Author: Alex Freidah
+#
+# Stands up a single-node cinc-server. Downloads the cinc-server .deb,
+# installs it, templates /etc/opscode/chef-server.rb, and runs
+# `chef-server-ctl reconfigure` when the config changes.
+# -------------------------------------------------------------------------------
+
+name             'cinc_server'
+maintainer       'Alex Freidah'
+maintainer_email 'alex.freidah@gmail.com'
+license          'MIT'
+description      'Installs and configures the cinc-server'
+version          '0.1.0'
+chef_version     '>= 17'
+issues_url       'https://github.com/afreidah/munchbox/issues'
+source_url       'https://github.com/afreidah/munchbox'
+
+depends 'munchbox_lib'
+
+supports 'debian'
+supports 'ubuntu'

--- a/infrastructure/cinc/cookbooks/cinc_server/recipes/configure.rb
+++ b/infrastructure/cinc/cookbooks/cinc_server/recipes/configure.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+# -------------------------------------------------------------------------------
+# Cookbook:: cinc_server
+# Recipe:: configure
+#
+# Templates /etc/opscode/chef-server.rb and runs `chef-server-ctl
+# reconfigure` whenever the config changes.
+# -------------------------------------------------------------------------------
+
+cinc_server_configure 'cinc-server' do
+  api_fqdn node[cookbook]['config']['api_fqdn']
+  settings node[cookbook]['config']['settings'].to_hash
+end

--- a/infrastructure/cinc/cookbooks/cinc_server/recipes/default.rb
+++ b/infrastructure/cinc/cookbooks/cinc_server/recipes/default.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+# -------------------------------------------------------------------------------
+# Cookbook:: cinc_server
+# Recipe:: default
+#
+# Intentionally empty. Compose the cookbook by including the targeted
+# sub-recipes (`cinc_server::install`, `cinc_server::configure`) from a
+# role or node run list -- never via `default`.
+# -------------------------------------------------------------------------------

--- a/infrastructure/cinc/cookbooks/cinc_server/recipes/install.rb
+++ b/infrastructure/cinc/cookbooks/cinc_server/recipes/install.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+# -------------------------------------------------------------------------------
+# Cookbook:: cinc_server
+# Recipe:: install
+#
+# Downloads the cinc-server .deb and installs it. Idempotent: dpkg_package
+# is a no-op once the package is present at the pinned version.
+# -------------------------------------------------------------------------------
+
+cinc_server_install 'cinc-server' do
+  url      node[cookbook]['install']['url']
+  version  node[cookbook]['install']['version']
+  checksum node[cookbook]['install']['checksum']
+end

--- a/infrastructure/cinc/cookbooks/cinc_server/resources/cinc_server_configure.rb
+++ b/infrastructure/cinc/cookbooks/cinc_server/resources/cinc_server_configure.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+# -------------------------------------------------------------------------------
+# Cookbook:: cinc_server
+# Resource:: cinc_server_configure
+#
+# Templates /etc/opscode/chef-server.rb and runs `chef-server-ctl
+# reconfigure` whenever the file changes. The reconfigure is a notify
+# (no action :run) so it only fires on real config drift, not every
+# converge.
+#
+# Properties:
+#   api_fqdn - The fqdn the server advertises (required).
+#   settings - Hash of `'directive[key]' => value-literal` pairs rendered
+#              verbatim into chef-server.rb. Values must be valid ruby
+#              literals (quote strings, etc.).
+# -------------------------------------------------------------------------------
+
+unified_mode true
+
+provides :cinc_server_configure
+
+property :api_fqdn, String, required: true
+property :settings, Hash, default: {}
+
+default_action :configure
+
+# --- Drop chef-server.rb, run reconfigure on change ---
+action :configure do
+  directory '/etc/opscode' do
+    owner 'root'
+    group 'root'
+    mode  '0755'
+  end
+
+  template '/etc/opscode/chef-server.rb' do
+    source 'chef-server.rb.erb'
+    owner  'root'
+    group  'root'
+    mode   '0644'
+    variables(api_fqdn: new_resource.api_fqdn, settings: new_resource.settings)
+    notifies :run, 'execute[chef-server-ctl reconfigure]', :immediately
+  end
+
+  execute 'chef-server-ctl reconfigure' do
+    command 'chef-server-ctl reconfigure'
+    # --- License accept is required since 14.x; harmless on older releases ---
+    environment 'CINC_LICENSE' => 'accept', 'CHEF_LICENSE' => 'accept'
+    action :nothing
+  end
+end
+
+# --- Remove the rendered config; do NOT auto-run reconfigure ---
+action :remove do
+  file '/etc/opscode/chef-server.rb' do
+    action :delete
+  end
+end

--- a/infrastructure/cinc/cookbooks/cinc_server/resources/cinc_server_install.rb
+++ b/infrastructure/cinc/cookbooks/cinc_server/resources/cinc_server_install.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+# -------------------------------------------------------------------------------
+# Cookbook:: cinc_server
+# Resource:: cinc_server_install
+#
+# Downloads the cinc-server .deb to /var/cache and installs it via
+# dpkg_package. cinc-server isn't published to a generic apt repo, so we
+# can't lean on apt_package + a source list.
+#
+# Properties:
+#   url      - Full URL to the .deb (required).
+#   version  - Pinned version string (required) -- used to gate dpkg_package
+#              upgrades and to disambiguate the cached download path.
+#   checksum - Optional SHA256. When set, remote_file enforces it and
+#              skips re-download if the cached file matches.
+# -------------------------------------------------------------------------------
+
+unified_mode true
+
+provides :cinc_server_install
+
+property :url,      String, required: true
+property :version,  String, required: true
+property :checksum, [String, nil]
+
+default_action :install
+
+# --- Fetch the .deb if needed and dpkg-install at the pinned version ---
+action :install do
+  cache_path = "/var/cache/cinc-server-#{new_resource.version}.deb"
+
+  remote_file cache_path do
+    source   new_resource.url
+    checksum new_resource.checksum if new_resource.checksum
+    owner    'root'
+    group    'root'
+    mode     '0644'
+    action   :create
+  end
+
+  dpkg_package 'cinc-server-core' do
+    source  cache_path
+    version "#{new_resource.version}-1"
+    action  :install
+  end
+end
+
+# --- Remove the package; leave the cached .deb alone in case we're reinstalling ---
+action :remove do
+  dpkg_package 'cinc-server-core' do
+    action :remove
+  end
+end

--- a/infrastructure/cinc/cookbooks/cinc_server/spec/recipes/configure_spec.rb
+++ b/infrastructure/cinc/cookbooks/cinc_server/spec/recipes/configure_spec.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+# -------------------------------------------------------------------------------
+# configure recipe spec -- step into the wrapping resource so we cover the
+# underlying template + execute it declares.
+# -------------------------------------------------------------------------------
+
+RSpec.describe 'cinc_server::configure' do
+  cached(:chef_run) do
+    ChefSpec::SoloRunner.new(step_into: %w(cinc_server_configure)).converge('cinc_server::configure')
+  end
+
+  # --- Wrapping resource gets credit for coverage ---
+  it 'declares the cinc_server_configure resource' do
+    expect(chef_run).to configure_cinc_server_configure('cinc-server')
+  end
+
+  # --- chef-server.rb is templated with correct perms ---
+  it 'templates /etc/opscode/chef-server.rb' do
+    expect(chef_run).to create_template('/etc/opscode/chef-server.rb')
+      .with(owner: 'root', group: 'root', mode: '0644')
+  end
+
+  # --- reconfigure is :nothing until the template notifies it ---
+  it 'declares chef-server-ctl reconfigure as a notify-only execute' do
+    expect(chef_run.execute('chef-server-ctl reconfigure')).to do_nothing
+  end
+
+  # --- Template change should fire an immediate reconfigure ---
+  it 'queues an immediate reconfigure when chef-server.rb changes' do
+    template = chef_run.template('/etc/opscode/chef-server.rb')
+    expect(template).to notify('execute[chef-server-ctl reconfigure]').to(:run).immediately
+  end
+end

--- a/infrastructure/cinc/cookbooks/cinc_server/spec/recipes/default_spec.rb
+++ b/infrastructure/cinc/cookbooks/cinc_server/spec/recipes/default_spec.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+# -------------------------------------------------------------------------------
+# default recipe spec -- recipe is intentionally empty so the only assertion
+# is that it loads and converges without declaring any resources.
+# -------------------------------------------------------------------------------
+
+RSpec.describe 'cinc_server::default' do
+  cached(:chef_run) { ChefSpec::SoloRunner.new.converge('cinc_server::default') }
+
+  it 'converges with no resources' do
+    expect(chef_run.resource_collection.to_a).to be_empty
+  end
+end

--- a/infrastructure/cinc/cookbooks/cinc_server/spec/recipes/install_spec.rb
+++ b/infrastructure/cinc/cookbooks/cinc_server/spec/recipes/install_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+# -------------------------------------------------------------------------------
+# install recipe spec -- step into the wrapping resource so we cover the
+# underlying remote_file + dpkg_package it declares.
+# -------------------------------------------------------------------------------
+
+RSpec.describe 'cinc_server::install' do
+  cached(:chef_run) do
+    ChefSpec::SoloRunner.new(step_into: %w(cinc_server_install)).converge('cinc_server::install')
+  end
+
+  # --- Declares the wrapping resource keyed by 'cinc-server' ---
+  it 'declares the cinc_server_install resource' do
+    expect(chef_run).to install_cinc_server_install('cinc-server')
+  end
+
+  # --- Underlying dpkg_package is queued at the pinned version ---
+  it 'installs cinc-server-core at the pinned version' do
+    expect(chef_run).to install_dpkg_package('cinc-server-core')
+      .with(version: '15.10.91-1')
+  end
+end

--- a/infrastructure/cinc/cookbooks/cinc_server/spec/spec_helper.rb
+++ b/infrastructure/cinc/cookbooks/cinc_server/spec/spec_helper.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+# -------------------------------------------------------------------------------
+# Cookbook:: cinc_server
+# Spec helper -- wires up chefspec with our cookbook path so the `cookbook`
+# helper from munchbox_lib resolves correctly when recipes and resources run.
+# -------------------------------------------------------------------------------
+
+require 'chefspec'
+
+# --- Load shared rspec/chefspec matchers (e.g. do_nothing) ---
+Dir[File.expand_path('support/**/*.rb', __dir__)].each { |f| require f }
+
+ChefSpec::Coverage.start! { add_filter 'munchbox_lib' }
+
+RSpec.configure do |config|
+  # --- Point chefspec at this cookbook + munchbox_lib next door ---
+  config.cookbook_path = [
+    File.expand_path('../../', __dir__),
+    File.expand_path('../../../munchbox_lib', __dir__),
+  ]
+
+  config.platform        = 'debian'
+  config.version         = '12'
+  config.log_level       = :error
+  config.disable_monkey_patching!
+  config.order = :random
+  Kernel.srand(config.seed)
+end

--- a/infrastructure/cinc/cookbooks/cinc_server/spec/support/matchers.rb
+++ b/infrastructure/cinc/cookbooks/cinc_server/spec/support/matchers.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+# -------------------------------------------------------------------------------
+# Custom rspec/chefspec matchers
+#
+# ChefSpec's auto-generated matchers call `ChefSpec::Coverage.cover!` on
+# the resource, which is how the coverage tracker decides a resource was
+# tested. Resources declared with `action :nothing` (e.g. an execute that
+# only runs on notify) never get hit by an action-named matcher, so they
+# always show up as untouched.
+#
+# `do_nothing` is a thin matcher that calls cover! and asserts the
+# resource's action is :nothing:
+#
+#   expect(chef_run.execute('chef-server-ctl reconfigure')).to do_nothing
+# -------------------------------------------------------------------------------
+
+RSpec::Matchers.define :do_nothing do
+  match do |resource|
+    next false unless resource
+
+    ChefSpec::Coverage.cover!(resource)
+    actions = Array(resource.action)
+    actions.include?(:nothing)
+  end
+
+  failure_message do |resource|
+    if resource.nil?
+      'expected a chef resource but got nil'
+    else
+      "expected #{resource} to have action :nothing, got #{Array(resource.action).inspect}"
+    end
+  end
+end

--- a/infrastructure/cinc/cookbooks/cinc_server/templates/chef-server.rb.erb
+++ b/infrastructure/cinc/cookbooks/cinc_server/templates/chef-server.rb.erb
@@ -1,0 +1,15 @@
+<%#
+  Cookbook:: cinc_server
+  Template:: chef-server.rb.erb
+
+  Renders /etc/opscode/chef-server.rb. `api_fqdn` is the one setting every
+  install must override; `settings` is a free-form hash of additional
+  `directive[key]` -> value-literal pairs (quote strings yourself).
+%>
+# Managed by chef (cinc_server::configure) -- do not edit by hand.
+
+api_fqdn '<%= @api_fqdn %>'
+
+<% @settings.each do |key, value| -%>
+<%= key %> <%= value %>
+<% end -%>

--- a/infrastructure/cinc/cookbooks/cinc_server/test/integration/default/controls/cinc_server.rb
+++ b/infrastructure/cinc/cookbooks/cinc_server/test/integration/default/controls/cinc_server.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+# -------------------------------------------------------------------------------
+# cinc_server integration controls
+#
+# One control per recipe. Verify: the package + binaries are on disk, the
+# templated config is what we expect, and `chef-server-ctl status` reports
+# every service as running.
+# -------------------------------------------------------------------------------
+
+control 'install' do
+  impact 1.0
+  title 'cinc_server::install installs the cinc-server-core package'
+
+  describe package('cinc-server-core') do
+    it { should be_installed }
+  end
+
+  describe file('/usr/bin/chef-server-ctl') do
+    it { should exist }
+    it { should be_executable }
+  end
+end
+
+control 'configure' do
+  impact 1.0
+  title 'cinc_server::configure templates chef-server.rb and reconfigures the server'
+
+  describe file('/etc/opscode/chef-server.rb') do
+    it { should exist }
+    its('mode') { should cmp '0644' }
+    its('content') { should match(/^api_fqdn 'cinc-server\.test'/) }
+  end
+
+  # --- Top-level systemd unit that owns the runit supervisor for all
+  # chef-server services. If this is down, nothing else can be up. ---
+  describe service('private_chef-runsvdir-start') do
+    it { should be_enabled }
+    it { should be_running }
+  end
+
+  # --- runit reports each managed service as "run:" -- this is the
+  # canonical chef-server health check ---
+  describe command('chef-server-ctl status') do
+    its('exit_status') { should eq 0 }
+    its('stdout') { should match(/run: postgresql:/) }
+    its('stdout') { should match(/run: nginx:/) }
+    its('stdout') { should match(/run: opscode-erchef:/) }
+  end
+
+  # --- /_status hits nginx -> opscode-erchef -> postgres -> bifrost, so
+  # "pong" here proves chef-server itself is responding end-to-end, not
+  # just nginx returning a 200 ---
+  describe command('curl -ksf https://localhost/_status') do
+    its('exit_status') { should eq 0 }
+    its('stdout') { should match(/"status":\s*"pong"/) }
+  end
+end

--- a/infrastructure/cinc/cookbooks/cinc_server/test/integration/default/inspec.yml
+++ b/infrastructure/cinc/cookbooks/cinc_server/test/integration/default/inspec.yml
@@ -1,0 +1,10 @@
+---
+name: cinc_server
+title: cinc_server integration controls
+maintainer: Alex Freidah
+copyright: Alex Freidah
+license: MIT
+summary: Validates a converged cinc_server node (package install + reconfigure).
+version: 0.1.0
+supports:
+  - platform: debian


### PR DESCRIPTION
## Summary
- Adds the cookbook that installs and configures a single-node cinc-server.
- `cinc_server::install` downloads the .deb from downloads.cinc.sh and dpkg-installs it; `cinc_server::configure` templates `/etc/opscode/chef-server.rb` and runs `chef-server-ctl reconfigure` only when the file changes. `default.rb` is empty per the style guide.
- v1 scope is intentionally minimal — no org/user bootstrap, no TLS, no backups. Tracked as follow-ups when the chef-server VM actually comes online.

## Test plan
- [x] `make lint` (cookstyle)
- [x] `make test` (chefspec)
- [x] `make kitchen` on debian-12 — package + binary on disk, runit supervisor up under systemd (`private_chef-runsvdir-start`), `chef-server-ctl status` green, `/_status` answers `"pong"` for every service.

Closes #87