### PR TITLE
GH_ISSUE_82: provision cinc-server VM via dir-keyed VM groups

### DIFF
--- a/infrastructure/terragrunt/_env_helpers/proxmox-cluster.hcl
+++ b/infrastructure/terragrunt/_env_helpers/proxmox-cluster.hcl
@@ -2,8 +2,11 @@
 # PROXMOX CLUSTER ENV HELPER
 # -----------------------------------------------------------------------------
 #
-# Manages on-prem Proxmox VMs for the Nomad/Consul cluster.
-# VMs are defined in root.hcl and configured via Ansible post-provision.
+# Manages a group of on-prem Proxmox VMs. The calling terragrunt directory's
+# name (e.g. `cluster`, `cinc-server`) selects which group from
+# `proxmox_vm_groups` in root.hcl gets provisioned, so a new VM group is
+# added by dropping a new directory under terragrunt/proxmox/ and adding
+# the matching key to root.hcl.
 #
 # Author: Alex Freidah / Project: Munchbox
 # -----------------------------------------------------------------------------
@@ -13,11 +16,13 @@ terraform {
 }
 
 locals {
-  root = read_terragrunt_config(find_in_parent_folders("root.hcl"))
+  root       = read_terragrunt_config(find_in_parent_folders("root.hcl"))
+  group_name = basename(get_terragrunt_dir())
+  group      = local.root.locals.proxmox_vm_groups[local.group_name]
 }
 
 inputs = {
-  vms            = local.root.locals.proxmox_vms
+  vms            = local.group
   disk_storage   = local.root.locals.proxmox_defaults.disk_storage
   network_bridge = local.root.locals.proxmox_defaults.network_bridge
   template_name  = try(local.root.locals.proxmox_defaults.template_name, "debian-base")

--- a/infrastructure/terragrunt/proxmox/cinc-server/terragrunt.hcl
+++ b/infrastructure/terragrunt/proxmox/cinc-server/terragrunt.hcl
@@ -1,9 +1,10 @@
 # -----------------------------------------------------------------------------
-# PROXMOX CLUSTER - On-Prem Nomad/Consul/Vault VMs
+# PROXMOX CINC-SERVER - Dedicated VM for cinc/chef server
 # -----------------------------------------------------------------------------
 #
-# Manages the VMs in root.hcl `proxmox_vm_groups.cluster` (matched by this
-# directory's name). Post-provisioning configuration is handled by Ansible.
+# Manages the VM in root.hcl `proxmox_vm_groups.cinc-server` (matched by this
+# directory's name). Hosts the cinc-server that will drive the chef migration
+# from ansible (see #81).
 #
 # -----------------------------------------------------------------------------
 

--- a/infrastructure/terragrunt/root.hcl
+++ b/infrastructure/terragrunt/root.hcl
@@ -94,71 +94,96 @@ locals {
   }
 
   # ---------------------------------------------------------------------------
-  # PROXMOX VMS (On-Prem Cluster)
+  # PROXMOX VM GROUPS
   # ---------------------------------------------------------------------------
-  # These are managed via Ansible post-provision, no cloud-init bootstrap
+  # Keyed by terragrunt subdir name under terragrunt/proxmox/. The
+  # _env_helpers/proxmox-cluster.hcl helper looks up the group via
+  # basename(get_terragrunt_dir()), so a directory named `cluster` reads
+  # `proxmox_vm_groups.cluster`, `cinc-server` reads
+  # `proxmox_vm_groups.cinc-server`, etc.
 
-  proxmox_vms = {
-    "nomad-server-03" = {
-      target_node = "fontana"
-      vmid        = 172
-      memory      = 2048
-      cores       = 2
-      disk_size   = "40G"
-      existing    = true
-    }
+  proxmox_vm_groups = {
+    # The main Nomad/Consul/Vault cluster. Existing VMs are managed via
+    # Ansible post-provision; cloud-init only set for the few that need it.
+    cluster = {
+      "nomad-server-03" = {
+        target_node = "fontana"
+        vmid        = 172
+        memory      = 2048
+        cores       = 2
+        disk_size   = "40G"
+        existing    = true
+      }
 
-    "nomad-client-01" = {
-      target_node = "fontana"
-      vmid        = 180
-      memory      = 13312
-      cores       = 4
-      disk_size   = "60G"
-      existing    = true
-    }
+      "nomad-client-01" = {
+        target_node = "fontana"
+        vmid        = 180
+        memory      = 13312
+        cores       = 4
+        disk_size   = "60G"
+        existing    = true
+      }
 
-    "nomad-client-02" = {
-      target_node = "mccoy"
-      vmid        = 181
-      memory      = 15360
-      cores       = 4
-      disk_size   = "40G"
-      existing    = true
-    }
+      "nomad-client-02" = {
+        target_node = "mccoy"
+        vmid        = 181
+        memory      = 15360
+        cores       = 4
+        disk_size   = "40G"
+        existing    = true
+      }
 
-    "nomad-client-03" = {
-      target_node = "cabot"
-      vmid        = 182
-      memory      = 7168
-      cores       = 4
-      disk_size   = "40G"
-      existing    = true
-    }
+      "nomad-client-03" = {
+        target_node = "cabot"
+        vmid        = 182
+        memory      = 7168
+        cores       = 4
+        disk_size   = "40G"
+        existing    = true
+      }
 
-    "nomad-client-04" = {
-      target_node     = "rubirosa"
-      vmid            = 183
-      memory          = 28672
-      cores           = 10
-      disk_size       = "140G"
-      gpu_passthrough = { pci_address = "0000:02:00.0" }
-      cloud_init = {
-        ip         = "192.168.68.73/24"
-        gateway    = "192.168.68.1"
-        nameserver = "192.168.68.62"
+      "nomad-client-04" = {
+        target_node     = "rubirosa"
+        vmid            = 183
+        memory          = 28672
+        cores           = 10
+        disk_size       = "140G"
+        gpu_passthrough = { pci_address = "0000:02:00.0" }
+        cloud_init = {
+          ip         = "192.168.68.73/24"
+          gateway    = "192.168.68.1"
+          nameserver = "192.168.68.62"
+        }
+      }
+
+      "nomad-client-05" = {
+        target_node = "rubirosa"
+        vmid        = 184
+        memory      = 28672
+        cores       = 10
+        disk_size   = "40G"
+        cloud_init = {
+          ip         = "192.168.68.74/24"
+          gateway    = "192.168.68.1"
+          nameserver = "192.168.68.62"
+        }
       }
     }
 
-    "nomad-client-05" = {
-      target_node = "rubirosa"
-      vmid        = 184
-      memory      = 28672
-      cores       = 10
-      disk_size   = "40G"
-      cloud_init = {
-        ip         = "192.168.68.74/24"
-        gateway    = "192.168.68.1"
-        nameserver = "192.168.68.62"
+    # Cinc/Chef server host. Provisioned as its own group so it can be
+    # applied independently of the cluster.
+    cinc-server = {
+      "cinc-server" = {
+        target_node = "rubirosa"
+        vmid        = 185
+        memory      = 4096
+        cores       = 2
+        disk_size   = "60G"
+        cloud_init = {
+          ip         = "192.168.68.76/24"
+          gateway    = "192.168.68.1"
+          nameserver = "192.168.68.62"
+        }
       }
     }
   }


### PR DESCRIPTION
## Summary
- Refactors `root.hcl` from a single `proxmox_vms` map into `proxmox_vm_groups` keyed by the terragrunt subdir name under `terragrunt/proxmox/`. The proxmox-cluster env helper picks the right group via `basename(get_terragrunt_dir())`, so a new VM group is just: new dir + matching key in `root.hcl`.
- Adds the `cinc-server` group with a single VM (2 vCPU, 4 GB RAM, 60 GB, .76 on rubirosa) for the cinc/chef server driving the ansible → chef migration (#81).

## Test plan
- [ ] `terragrunt plan` under `terragrunt/proxmox/cinc-server/` shows one new VM
- [ ] `terragrunt plan` under `terragrunt/proxmox/cluster/` shows zero drift (refactor only)
- [ ] `terragrunt apply` provisions the VM, it boots, SSH key works

Closes #82