### PR TITLE
GH_ISSUE_90: attach cloud-init drive to proxmox VMs

### DIFF
--- a/infrastructure/modules/proxmox-cluster/main.tf
+++ b/infrastructure/modules/proxmox-cluster/main.tf
@@ -36,6 +36,20 @@ resource "proxmox_vm_qemu" "vm" {
     size    = each.value.disk_size
   }
 
+  # Cloud-init CD-ROM drive. Only attached when `cloud_init.storage` is
+  # set on the VM. Without this drive, ciuser / ipconfig0 / etc. live in
+  # the VM config but never reach the guest -- so cloud_init.storage is
+  # effectively required for any VM that relies on terraform-managed
+  # cloud-init data.
+  dynamic "disk" {
+    for_each = try(each.value.cloud_init.storage, null) != null ? [each.value.cloud_init.storage] : []
+    content {
+      slot    = "ide2"
+      type    = "cloudinit"
+      storage = disk.value
+    }
+  }
+
   # Networking
   network {
     id     = 0
@@ -47,7 +61,11 @@ resource "proxmox_vm_qemu" "vm" {
   onboot = try(each.value.onboot, true)
   agent  = try(each.value.qemu_agent, true) ? 1 : 0
 
-  # Cloud-init (optional)
+  # Cloud-init (optional). The actual CD-ROM drive is attached via the
+  # dynamic disk block above (gated on `cloud_init.storage`). Without that
+  # drive these settings are written to the VM config but never reach the
+  # guest, so any VM relying on terraform-managed cloud-init data needs
+  # `cloud_init.storage` set.
   ciuser     = try(each.value.cloud_init.user, null)
   ipconfig0  = try(each.value.cloud_init, null) != null ? "ip=${each.value.cloud_init.ip},gw=${each.value.cloud_init.gateway}" : null
   nameserver = try(each.value.cloud_init.nameserver, null)

--- a/infrastructure/modules/proxmox-cluster/variables.tf
+++ b/infrastructure/modules/proxmox-cluster/variables.tf
@@ -23,6 +23,10 @@ variable "vms" {
       gateway    = string
       nameserver = optional(string)
       sshkeys    = optional(string)
+      # --- Proxmox storage ID for the auto-attached cloud-init CD-ROM.
+      # Leave null for VMs whose cloud-init drive was created out-of-band
+      # so terraform doesn't try to reconcile that drive. ---
+      storage    = optional(string)
     }), null)
   }))
 }

--- a/infrastructure/terragrunt/root.hcl
+++ b/infrastructure/terragrunt/root.hcl
@@ -183,6 +183,9 @@ locals {
           ip         = "192.168.68.76/24"
           gateway    = "192.168.68.1"
           nameserver = "192.168.68.62"
+          # Attach a cloud-init CD-ROM so the OS can actually read the
+          # ipconfig0 / ciuser settings above.
+          storage = "local-lvm"
         }
       }
     }


### PR DESCRIPTION
## Summary
- cinc-server (#82) was provisioned with `ipconfig0` / `ciuser` in the proxmox config but no cloud-init CD-ROM drive, so the guest had nowhere to read those settings from — booted with no static IP, never reachable on .76.
- Adds an opt-in `cloud_init.storage` field on the `proxmox-cluster` module; when set, attaches a cloud-init drive via `disk { type = "cloudinit" }`.
- Opts the cinc-server VM in. Other VMs that already have a drive attached out-of-band (e.g. `nomad-client-04`) leave the field unset so terraform doesn't try to reconcile their drives.

## Test plan
- [ ] `terragrunt plan` under `terragrunt/proxmox/cinc-server/` shows only the cloud-init drive being added to vmid 185
- [ ] `terragrunt plan` under `terragrunt/proxmox/cluster/` shows no drift (other VMs don't set `storage`)
- [ ] `terragrunt apply`, then `ssh root@192.168.68.76 'hostname'` succeeds

Closes #90