### PR TITLE
GH_ISSUE_92: move cinc-server VM IP from .76 to .99

### DIFF
--- a/infrastructure/terragrunt/root.hcl
+++ b/infrastructure/terragrunt/root.hcl
@@ -180,7 +180,7 @@ locals {
         cores       = 2
         disk_size   = "60G"
         cloud_init = {
-          ip         = "192.168.68.76/24"
+          ip         = "192.168.68.99/24"
           gateway    = "192.168.68.1"
           nameserver = "192.168.68.62"
           # Attach a cloud-init CD-ROM so the OS can actually read the


### PR DESCRIPTION
## Summary
- `.76` is intermittently claimed by another device on the homelab LAN (Liteon OUI). Cloud-init couldn't reliably hold the static IP for the cinc-server VM.
- `.99` is verified silent across a multi-probe ping sweep from a same-subnet host.

## Test plan
- [ ] `terragrunt destroy && terragrunt apply` under `terragrunt/proxmox/cinc-server/`
- [ ] `ssh root@192.168.68.99 'hostname'` succeeds

Closes #92