### PR TITLE
GH_ISSUE_94: wire ssh public key into cinc-server cloud-init

### DIFF
--- a/infrastructure/terragrunt/root.hcl
+++ b/infrastructure/terragrunt/root.hcl
@@ -183,6 +183,7 @@ locals {
           ip         = "192.168.68.99/24"
           gateway    = "192.168.68.1"
           nameserver = "192.168.68.62"
+          sshkeys    = local.ssh_public_key
           # Attach a cloud-init CD-ROM so the OS can actually read the
           # ipconfig0 / ciuser settings above.
           storage = "local-lvm"


### PR DESCRIPTION
## Summary
- cinc-server VM came up at .99 but ssh rejected with `Permission denied (publickey)` because the cloud_init block didn't set `sshkeys` — cloud-init reset `/root/.ssh/authorized_keys`.
- Pass `local.ssh_public_key` (combined local + stabler keys already used elsewhere in root.hcl).

## Test plan
- [ ] `terragrunt destroy && terragrunt apply` under `terragrunt/proxmox/cinc-server/`
- [ ] `ssh root@192.168.68.99 'hostname'` succeeds

Closes #94