### PR TITLE
GH_ISSUE_96: onboard cinc-server VM into Vault SSH CA via ansible

### DIFF
--- a/infrastructure/ansible/inventory/hosts.yml
+++ b/infrastructure/ansible/inventory/hosts.yml
@@ -42,11 +42,11 @@ all:
           ansible_host: 192.168.68.74
           static_ip: 192.168.68.74
         oracle-node-1:
-          ansible_host: 132.226.87.58
-          static_ip: 132.226.87.58
+          ansible_host: 141.148.136.142
+          static_ip: 141.148.136.142
         oracle-node-2:
-          ansible_host: 158.101.33.133
-          static_ip: 158.101.33.133
+          ansible_host: 129.146.94.109
+          static_ip: 129.146.94.109
         oracle-arm-1:
           ansible_host: 132.226.26.135
           static_ip: 132.226.26.135
@@ -66,15 +66,6 @@ all:
           static_ip: 192.168.68.58
     consul_clients:
       hosts:
-        cabot:
-          ansible_host: 192.168.68.59
-          static_ip: 192.168.68.59
-        mccoy:
-          ansible_host: 192.168.68.63
-          static_ip: 192.168.68.63
-        fontana:
-          ansible_host: 192.168.68.65
-          static_ip: 192.168.68.65
         nomad-client-01:
           ansible_host: 192.168.68.67
           static_ip: 192.168.68.67
@@ -91,11 +82,11 @@ all:
           ansible_host: 192.168.68.74
           static_ip: 192.168.68.74
         oracle-node-1:
-          ansible_host: 132.226.87.58
-          static_ip: 132.226.87.58
+          ansible_host: 141.148.136.142
+          static_ip: 141.148.136.142
         oracle-node-2:
-          ansible_host: 158.101.33.133
-          static_ip: 158.101.33.133
+          ansible_host: 129.146.94.109
+          static_ip: 129.146.94.109
         oracle-arm-1:
           ansible_host: 132.226.26.135
           static_ip: 132.226.26.135
@@ -126,6 +117,11 @@ all:
         nomad-client-05:
           ansible_host: 192.168.68.74
           static_ip: 192.168.68.74
+    cinc_servers:
+      hosts:
+        cinc-server:
+          ansible_host: 192.168.68.99
+          static_ip: 192.168.68.99
     proxmox_hosts:
       hosts:
         cabot:
@@ -139,11 +135,11 @@ all:
     cloud_nodes:
       hosts:
         oracle-node-1:
-          ansible_host: 132.226.87.58
-          static_ip: 132.226.87.58
+          ansible_host: 141.148.136.142
+          static_ip: 141.148.136.142
         oracle-node-2:
-          ansible_host: 158.101.33.133
-          static_ip: 158.101.33.133
+          ansible_host: 129.146.94.109
+          static_ip: 129.146.94.109
         oracle-arm-1:
           ansible_host: 132.226.26.135
           static_ip: 132.226.26.135

--- a/infrastructure/ansible/playbooks/ssh-ca-setup.yml
+++ b/infrastructure/ansible/playbooks/ssh-ca-setup.yml
@@ -14,7 +14,7 @@
 # -------------------------------------------------------------------------------
 
 - name: Deploy SSH CA configuration
-  hosts: nomad_servers:nomad_clients:proxmox_hosts
+  hosts: nomad_servers:nomad_clients:proxmox_hosts:cinc_servers
   become: true
   serial: 3
   roles:

--- a/infrastructure/nodes.yml
+++ b/infrastructure/nodes.yml
@@ -180,6 +180,17 @@ vms:
       - ingress
     notes: "High-performance general workload client + Traefik standby"
 
+  cinc-server:
+    proxmox_host: rubirosa
+    vmid: 185
+    ip: 192.168.68.99
+    cores: 2
+    memory_mb: 4096
+    disk_gb: 60
+    roles:
+      - cinc_server
+    notes: "Cinc/Chef server (chef migration #81). VM lifecycle managed by terragrunt; this entry exists so ansible can target it for ssh-ca onboarding until the chef-side bootstrap takes over."
+
 # -------------------------------------------------------------------------------
 # Cloud Nodes (Oracle Cloud Free Tier)
 #

--- a/infrastructure/scripts/generate-inventory.py
+++ b/infrastructure/scripts/generate-inventory.py
@@ -79,6 +79,7 @@ def build_inventory(config):
                 "vault_servers": {"hosts": {}},
                 "gpu_nodes": {"hosts": {}},
                 "ingress": {"hosts": {}},
+                "cinc_servers": {"hosts": {}},
                 "proxmox_hosts": {"hosts": {}},
                 "cloud_nodes": {
                     "hosts": {},
@@ -130,6 +131,9 @@ def build_inventory(config):
 
         if "ingress" in roles:
             inventory["all"]["children"]["ingress"]["hosts"][name] = host_entry.copy()
+
+        if "cinc_server" in roles:
+            inventory["all"]["children"]["cinc_servers"]["hosts"][name] = host_entry.copy()
 
         # Add cloud nodes to their own group
         if data.get("type") == "cloud":


### PR DESCRIPTION
## Summary
- cinc-server VM (#82) needs the same Vault SSH CA host cert + trusted user CA setup as every other node so the workstation can SSH in cleanly via `@cert-authority *`. Until the chef migration ports `ssh-ca`, this stays in ansible.
- Add cinc-server to `infrastructure/nodes.yml` (vms section, role `cinc_server`). Tracked in memory: delete `nodes.yml` + generators once chef takes over post-provision config.
- Map `cinc_server` role → `cinc_servers` group in `scripts/generate-inventory.py`.
- Include `cinc_servers` in the `ssh-ca-setup.yml` playbook host pattern.
- Regenerated `ansible/inventory/hosts.yml` via `make generate`.

## Test plan
- [ ] `ansible-playbook -i infrastructure/ansible/inventory/hosts.yml infrastructure/ansible/playbooks/ssh-ca-setup.yml --limit cinc-server`
- [ ] `ssh root@192.168.68.99 'hostname'` succeeds with no host-key warning

Closes #96