### PR TITLE
GH_ISSUE_98: cron prereq + bootstrap (org/user) + parameterized install

### DIFF
--- a/MUNCHBOX_STYLE_GUIDE.md
+++ b/MUNCHBOX_STYLE_GUIDE.md
@@ -273,6 +273,100 @@ if !ok {
 }
 ```
 
+### Ruby / Chef (Cinc) Files
+
+Applies to chef/cinc cookbooks under `infrastructure/cinc/` (resources,
+recipes, libraries, attributes, templates) and any other Ruby code.
+
+```ruby
+# frozen_string_literal: true
+
+# -------------------------------------------------------------------------------
+# Cookbook:: <cookbook_name>
+# Resource:: <resource_name>
+#
+# 2-4 sentences describing what the resource/recipe/library does, key
+# properties or behaviours, and any important caveats.
+# -------------------------------------------------------------------------------
+
+unified_mode true
+
+provides :<resource_name>
+```
+
+**Ruby/Chef-Specific Rules:**
+- Use `#` comments (Ruby has no block comment syntax we use)
+- File headers use 79-char `# ---...---` dividers
+- Major sections within a file use 73-char `# ---...---` dividers with blank line AFTER
+- Single-line markers: `# --- description ---` (no blank line after)
+- `# frozen_string_literal: true` magic comment is always the first line; one blank line, then the file header box
+- Cookbook namespace via the `cookbook` helper from `munchbox_lib` (e.g. `default[cookbook]['key']`); never hardcode the cookbook name
+- Custom resources set `unified_mode true` and declare `provides :resource_name`
+- `default.rb` recipe stays empty; compose by listing per-concern sub-recipes in the run list
+- One targeted resource per concern; one recipe per resource
+
+**Binary comment rule (strict):**
+
+Every comment is either a single-line `# --- text ---` marker OR a full
+box comment. There is **no in-between multi-line `# foo` / `# bar` form**.
+If an inline note feels too long for one line, promote it to a box section
+(blank line after); otherwise compress it into one `# --- ... ---` line.
+
+```ruby
+# --- Drop conf.d override, enable+start sshd, restart on change ---
+action :configure do
+  template '/etc/ssh/sshd_config.d/00-munchbox.conf' do
+    source 'sshd-munchbox.conf.erb'
+    mode   '0644'
+    variables(settings: new_resource.settings)
+    notifies :restart, 'service[ssh]', :delayed
+  end
+
+  service 'ssh' do
+    action %i(enable start)
+  end
+end
+```
+
+**Wrong** (multi-line inline form):
+```ruby
+action :configure do
+  # apt_repository shells out to gpg to verify the signing key
+  # and may also need https transport. Install both first.
+  package %w(gnupg apt-transport-https ca-certificates)
+end
+```
+
+**Right** (compress to one line):
+```ruby
+action :configure do
+  # --- apt_repository needs gpg + https transport at compile time ---
+  package %w(gnupg apt-transport-https ca-certificates)
+end
+```
+
+Or, if the explanation genuinely deserves multiple lines, promote it to a
+section box:
+```ruby
+action :configure do
+  # -------------------------------------------------------------------------
+  # Prerequisites
+  #
+  # apt_repository shells out to gpg to verify the signing key + may need
+  # https transport for the apt_repository fetch. Both must be present
+  # before the repository resource runs.
+  # -------------------------------------------------------------------------
+
+  package %w(gnupg apt-transport-https ca-certificates)
+end
+```
+
+**Testing rules:**
+- Every resource/recipe gets chefspec coverage (run via `make test`)
+- Cookstyle (`make lint`) must pass with no offenses
+- Test-Kitchen via `make kitchen` (vagrant-libvirt) for end-to-end validation when systemd or real services are involved
+- InSpec controls live under `test/integration/default/controls/`
+
 ---
 
 ## Nomad Job Structure

--- a/infrastructure/cinc/cookbooks/cinc_server/attributes/default.rb
+++ b/infrastructure/cinc/cookbooks/cinc_server/attributes/default.rb
@@ -21,6 +21,7 @@ default[cookbook]['install'] = {
   'version' => '15.10.91',
   'url' => 'https://downloads.cinc.sh/files/stable/cinc-server/15.10.91/debian/12/cinc-server-core_15.10.91-1_amd64.deb',
   'checksum' => nil,
+  'package_name' => 'cinc-server-core',
 }
 
 # -------------------------------------------------------------------------------
@@ -35,5 +36,29 @@ default[cookbook]['config'] = {
   'api_fqdn' => 'cinc-server.local',
   'settings' => {
     "nginx['enable_non_ssl']" => 'true',
+  },
+}
+
+# -------------------------------------------------------------------------------
+# Initial org + admin user (cinc_server::bootstrap)
+#
+# Override these per-node (especially `password`) before running the
+# bootstrap recipe. The captured admin private key is written to
+# `key_path` -- pick a directory that's tight on perms and out of the
+# repo, since this key has full server admin rights.
+# -------------------------------------------------------------------------------
+
+default[cookbook]['bootstrap'] = {
+  'org' => {
+    'short_name' => 'munchbox',
+    'full_name'  => 'Munchbox',
+  },
+  'user' => {
+    'username'   => 'alex',
+    'first_name' => 'Alex',
+    'last_name'  => 'Freidah',
+    'email'      => 'alex.freidah@gmail.com',
+    'password'   => 'CHANGEME-set-via-attribute-override',
+    'key_path'   => '/etc/cinc-bootstrap/alex.pem',
   },
 }

--- a/infrastructure/cinc/cookbooks/cinc_server/kitchen.yml
+++ b/infrastructure/cinc/cookbooks/cinc_server/kitchen.yml
@@ -39,6 +39,7 @@ suites:
     run_list:
       - recipe[cinc_server::install]
       - recipe[cinc_server::configure]
+      - recipe[cinc_server::bootstrap]
     attributes:
       cinc_server:
         config:
@@ -47,3 +48,7 @@ suites:
           api_fqdn: cinc-server.test
           settings:
             "nginx['enable_non_ssl']": 'true'
+        bootstrap:
+          user:
+            password: kitchen-test-temp-password
+            key_path: /etc/cinc-bootstrap/alex.pem

--- a/infrastructure/cinc/cookbooks/cinc_server/recipes/bootstrap.rb
+++ b/infrastructure/cinc/cookbooks/cinc_server/recipes/bootstrap.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+# -------------------------------------------------------------------------------
+# Cookbook:: cinc_server
+# Recipe:: bootstrap
+#
+# Creates the initial org + admin user so the server is actually usable
+# from `knife`. Both resources are idempotent (org-show / user-show
+# gating), so this recipe is safe to leave in every converge.
+# -------------------------------------------------------------------------------
+
+cinc_server_org node[cookbook]['bootstrap']['org']['short_name'] do
+  full_name node[cookbook]['bootstrap']['org']['full_name']
+end
+
+cinc_server_user node[cookbook]['bootstrap']['user']['username'] do
+  first_name node[cookbook]['bootstrap']['user']['first_name']
+  last_name  node[cookbook]['bootstrap']['user']['last_name']
+  email      node[cookbook]['bootstrap']['user']['email']
+  password   node[cookbook]['bootstrap']['user']['password']
+  key_path   node[cookbook]['bootstrap']['user']['key_path']
+  org        node[cookbook]['bootstrap']['org']['short_name']
+end

--- a/infrastructure/cinc/cookbooks/cinc_server/recipes/install.rb
+++ b/infrastructure/cinc/cookbooks/cinc_server/recipes/install.rb
@@ -9,7 +9,8 @@
 # -------------------------------------------------------------------------------
 
 cinc_server_install 'cinc-server' do
-  url      node[cookbook]['install']['url']
-  version  node[cookbook]['install']['version']
-  checksum node[cookbook]['install']['checksum']
+  url          node[cookbook]['install']['url']
+  version      node[cookbook]['install']['version']
+  checksum     node[cookbook]['install']['checksum']
+  package_name node[cookbook]['install']['package_name']
 end

--- a/infrastructure/cinc/cookbooks/cinc_server/resources/cinc_server_configure.rb
+++ b/infrastructure/cinc/cookbooks/cinc_server/resources/cinc_server_configure.rb
@@ -21,7 +21,7 @@ unified_mode true
 provides :cinc_server_configure
 
 property :api_fqdn, String, required: true
-property :settings, Hash, default: {}
+property :settings, Hash,   default: {}
 
 default_action :configure
 

--- a/infrastructure/cinc/cookbooks/cinc_server/resources/cinc_server_install.rb
+++ b/infrastructure/cinc/cookbooks/cinc_server/resources/cinc_server_install.rb
@@ -4,31 +4,41 @@
 # Cookbook:: cinc_server
 # Resource:: cinc_server_install
 #
-# Downloads the cinc-server .deb to /var/cache and installs it via
-# dpkg_package. cinc-server isn't published to a generic apt repo, so we
-# can't lean on apt_package + a source list.
+# Downloads the Chef Infra Server omnibus .deb to /var/cache and installs
+# it via dpkg_package. Defaults install cinc-server-core from
+# downloads.cinc.sh; overriding url/version/package_name flips the
+# cookbook to upstream chef-server-core or any compatible build without
+# touching the resource code.
 #
 # Properties:
-#   url      - Full URL to the .deb (required).
-#   version  - Pinned version string (required) -- used to gate dpkg_package
-#              upgrades and to disambiguate the cached download path.
-#   checksum - Optional SHA256. When set, remote_file enforces it and
-#              skips re-download if the cached file matches.
+#   url          - Full URL to the .deb (required).
+#   version      - Pinned version string (required) -- used to gate dpkg_package
+#                  upgrades and to disambiguate the cached download path.
+#   checksum     - Optional SHA256. When set, remote_file enforces it and
+#                  skips re-download if the cached file matches.
+#   package_name - dpkg package name to install/remove (required, e.g.
+#                  cinc-server-core or chef-server-core).
 # -------------------------------------------------------------------------------
 
 unified_mode true
 
 provides :cinc_server_install
 
-property :url,      String, required: true
-property :version,  String, required: true
-property :checksum, [String, nil]
+property :url,          String, required: true
+property :version,      String, required: true
+property :checksum,     [String, nil]
+property :package_name, String, required: true
 
 default_action :install
 
 # --- Fetch the .deb if needed and dpkg-install at the pinned version ---
 action :install do
-  cache_path = "/var/cache/cinc-server-#{new_resource.version}.deb"
+  # --- infra-server::log_cleanup writes to /etc/cron.hourly; Debian 12 cloud image needs cron installed first ---
+  package 'cron' do
+    action :install
+  end
+
+  cache_path = "/var/cache/#{new_resource.package_name}-#{new_resource.version}.deb"
 
   remote_file cache_path do
     source   new_resource.url
@@ -39,7 +49,7 @@ action :install do
     action   :create
   end
 
-  dpkg_package 'cinc-server-core' do
+  dpkg_package new_resource.package_name do
     source  cache_path
     version "#{new_resource.version}-1"
     action  :install
@@ -48,7 +58,7 @@ end
 
 # --- Remove the package; leave the cached .deb alone in case we're reinstalling ---
 action :remove do
-  dpkg_package 'cinc-server-core' do
+  dpkg_package new_resource.package_name do
     action :remove
   end
 end

--- a/infrastructure/cinc/cookbooks/cinc_server/resources/cinc_server_org.rb
+++ b/infrastructure/cinc/cookbooks/cinc_server/resources/cinc_server_org.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+# -------------------------------------------------------------------------------
+# Cookbook:: cinc_server
+# Resource:: cinc_server_org
+#
+# Idempotently creates an organization via `chef-server-ctl org-create`.
+# `org-show` is the existence check -- exits 0 if present, non-zero if not.
+#
+# Properties:
+#   short_name - Org slug used in API paths (default: resource name).
+#   full_name  - Human-readable org name (required).
+# -------------------------------------------------------------------------------
+
+unified_mode true
+
+provides :cinc_server_org
+
+property :short_name, String, name_property: true
+property :full_name,  String, required: true
+
+default_action :create
+
+# --- Create the org if it doesn't already exist ---
+action :create do
+  execute "chef-server-ctl org-create #{new_resource.short_name}" do
+    command "chef-server-ctl org-create '#{new_resource.short_name}' '#{new_resource.full_name}'"
+    environment 'CINC_LICENSE' => 'accept', 'CHEF_LICENSE' => 'accept'
+    not_if "chef-server-ctl org-show '#{new_resource.short_name}'"
+  end
+end
+
+# --- Tear an org down (rarely useful; mostly for test cleanup) ---
+action :delete do
+  execute "chef-server-ctl org-delete #{new_resource.short_name}" do
+    command "chef-server-ctl org-delete '#{new_resource.short_name}' --yes"
+    environment 'CINC_LICENSE' => 'accept', 'CHEF_LICENSE' => 'accept'
+    only_if "chef-server-ctl org-show '#{new_resource.short_name}'"
+  end
+end

--- a/infrastructure/cinc/cookbooks/cinc_server/resources/cinc_server_user.rb
+++ b/infrastructure/cinc/cookbooks/cinc_server/resources/cinc_server_user.rb
@@ -1,0 +1,86 @@
+# frozen_string_literal: true
+
+# -------------------------------------------------------------------------------
+# Cookbook:: cinc_server
+# Resource:: cinc_server_user
+#
+# Idempotently creates a server user via `chef-server-ctl user-create`,
+# capturing the generated private key to `key_path`. `user-show` is the
+# existence check. When `org` is set, the user is also added to that org
+# as an admin so they can manage cookbooks/nodes from `knife`.
+#
+# Properties:
+#   username   - Login name (default: resource name).
+#   first_name - Given name (required).
+#   last_name  - Family name (required).
+#   email      - Email address (required).
+#   password   - Initial password (required; user can rotate later).
+#   key_path   - Where to write the generated private key (required).
+#   org        - Optional org short_name to add the user to as admin.
+# -------------------------------------------------------------------------------
+
+unified_mode true
+
+provides :cinc_server_user
+
+property :username,   String, name_property: true
+property :first_name, String, required: true
+property :last_name,  String, required: true
+property :email,      String, required: true
+property :password,   String, required: true, sensitive: true
+property :key_path,   String, required: true
+property :org,        String
+
+default_action :create
+
+# --- Create the user (and its key) + optionally add to an org as admin ---
+action :create do
+  # --- Ensure parent dir for the captured pem exists with restrictive perms ---
+  directory ::File.dirname(new_resource.key_path) do
+    owner 'root'
+    group 'root'
+    mode  '0700'
+    recursive true
+  end
+
+  execute "chef-server-ctl user-create #{new_resource.username}" do
+    command [
+      'chef-server-ctl', 'user-create',
+      new_resource.username,
+      new_resource.first_name,
+      new_resource.last_name,
+      new_resource.email,
+      new_resource.password,
+      '--filename', new_resource.key_path
+    ]
+    environment 'CINC_LICENSE' => 'accept', 'CHEF_LICENSE' => 'accept'
+    sensitive true
+    not_if "chef-server-ctl user-show '#{new_resource.username}'"
+  end
+
+  # --- Lock down the captured key regardless of how chef-server-ctl wrote it ---
+  file new_resource.key_path do
+    owner 'root'
+    group 'root'
+    mode  '0600'
+    action :touch
+    only_if { ::File.exist?(new_resource.key_path) }
+  end
+
+  if new_resource.org
+    execute "chef-server-ctl org-user-add #{new_resource.org} #{new_resource.username} --admin" do
+      command "chef-server-ctl org-user-add '#{new_resource.org}' '#{new_resource.username}' --admin"
+      environment 'CINC_LICENSE' => 'accept', 'CHEF_LICENSE' => 'accept'
+      not_if "chef-server-ctl org-user-list '#{new_resource.org}' | grep -qx '#{new_resource.username}'"
+    end
+  end
+end
+
+# --- Remove the user (test cleanup; deletes the captured pem too) ---
+action :delete do
+  execute "chef-server-ctl user-delete #{new_resource.username}" do
+    command "chef-server-ctl user-delete '#{new_resource.username}' --yes"
+    environment 'CINC_LICENSE' => 'accept', 'CHEF_LICENSE' => 'accept'
+    only_if "chef-server-ctl user-show '#{new_resource.username}'"
+  end
+end

--- a/infrastructure/cinc/cookbooks/cinc_server/spec/recipes/bootstrap_spec.rb
+++ b/infrastructure/cinc/cookbooks/cinc_server/spec/recipes/bootstrap_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+# -------------------------------------------------------------------------------
+# bootstrap recipe spec
+# -------------------------------------------------------------------------------
+
+RSpec.describe 'cinc_server::bootstrap' do
+  # --- Resource not_if guards shell out to chef-server-ctl; stub them so chefspec doesn't try to run them ---
+  before do
+    stub_command("chef-server-ctl org-show 'munchbox'").and_return(false)
+    stub_command("chef-server-ctl user-show 'alex'").and_return(false)
+    stub_command("chef-server-ctl org-user-list 'munchbox' | grep -qx 'alex'").and_return(false)
+  end
+
+  cached(:chef_run) do
+    ChefSpec::SoloRunner.new(step_into: %w(cinc_server_org cinc_server_user)).converge('cinc_server::bootstrap')
+  end
+
+  # --- Declares the org wrapping resource with the configured names ---
+  it 'declares the munchbox org' do
+    expect(chef_run).to create_cinc_server_org('munchbox')
+      .with(full_name: 'Munchbox')
+  end
+
+  # --- Declares the admin user wrapping resource and ties it to the org ---
+  it 'declares the alex admin user tied to the munchbox org' do
+    expect(chef_run).to create_cinc_server_user('alex')
+      .with(
+        first_name: 'Alex',
+        last_name:  'Freidah',
+        email:      'alex.freidah@gmail.com',
+        org:        'munchbox'
+      )
+  end
+
+  # --- /etc/cinc-bootstrap dir is created before user-create writes the pem there ---
+  it 'creates the bootstrap key directory with restrictive perms' do
+    expect(chef_run).to create_directory('/etc/cinc-bootstrap')
+      .with(owner: 'root', group: 'root', mode: '0700')
+  end
+end

--- a/infrastructure/cinc/cookbooks/cinc_server/test/integration/default/controls/cinc_server.rb
+++ b/infrastructure/cinc/cookbooks/cinc_server/test/integration/default/controls/cinc_server.rb
@@ -48,11 +48,36 @@ control 'configure' do
     its('stdout') { should match(/run: opscode-erchef:/) }
   end
 
-  # --- /_status hits nginx -> opscode-erchef -> postgres -> bifrost, so
-  # "pong" here proves chef-server itself is responding end-to-end, not
-  # just nginx returning a 200 ---
+  # --- /_status hits nginx -> opscode-erchef -> postgres -> bifrost; "pong" proves chef-server is responding end-to-end ---
   describe command('curl -ksf https://localhost/_status') do
     its('exit_status') { should eq 0 }
     its('stdout') { should match(/"status":\s*"pong"/) }
+  end
+end
+
+control 'bootstrap' do
+  impact 1.0
+  title 'cinc_server::bootstrap creates the initial org + admin user'
+
+  describe command("chef-server-ctl org-show 'munchbox'") do
+    its('exit_status') { should eq 0 }
+  end
+
+  describe command("chef-server-ctl user-show 'alex'") do
+    its('exit_status') { should eq 0 }
+    its('stdout') { should match(/email:\s*alex\.freidah@gmail\.com/) }
+  end
+
+  describe file('/etc/cinc-bootstrap/alex.pem') do
+    it { should exist }
+    its('mode') { should cmp '0600' }
+    its('owner') { should eq 'root' }
+    its('content') { should match(/BEGIN (RSA )?PRIVATE KEY/) }
+  end
+
+  # --- alex should be an admin of the munchbox org ---
+  describe command("chef-server-ctl org-user-list 'munchbox'") do
+    its('exit_status') { should eq 0 }
+    its('stdout') { should match(/^alex$/) }
   end
 end


### PR DESCRIPTION
## Summary
- `cinc_server::install`: install `cron` as a debian prereq (Debian 12 cloud image ships without it, so `infra-server::log_cleanup` fails on missing `/etc/cron.hourly`).
- New resources `cinc_server_org` + `cinc_server_user` + recipe `cinc_server::bootstrap` to idempotently create the initial org (munchbox) and admin user (alex). Captures the admin private key to a known path so the workstation can fetch it for knife.
- Promote `package_name` to an attribute so the cookbook can be flipped between `cinc-server-core` and `chef-server-core` from kitchen/roles without code changes.
- Update `MUNCHBOX_STYLE_GUIDE.md` with the Ruby/Chef binary comment rule.

## Known gap (not addressed here)
cinc-server 15.10.91 ships a broken `partybus/config.rb` — `chef-server-ctl reconfigure` blows up on `partybus init` on a fresh install. That's an upstream cinc-server bug, not a cookbook concern; the workaround does not belong in this cookbook. To be tracked as an upstream issue. The live VM is unstuck via a manual hand-written `config.rb`.

## Test plan
- [x] `make lint` (cookstyle)
- [x] `make test` (chefspec)
- [ ] `make kitchen` will currently fail on the partybus bug — gated until upstream fix or a version pin

Closes #98