### PR TITLE
GH_ISSUE_102: cinc-server FQDN via pihole + cookbook attribute

### DIFF
--- a/infrastructure/cinc/cookbooks/cinc_server/attributes/default.rb
+++ b/infrastructure/cinc/cookbooks/cinc_server/attributes/default.rb
@@ -33,7 +33,7 @@ default[cookbook]['install'] = {
 # -------------------------------------------------------------------------------
 
 default[cookbook]['config'] = {
-  'api_fqdn' => 'cinc-server.local',
+  'api_fqdn' => 'cinc-server.munchbox.cc',
   'settings' => {
     "nginx['enable_non_ssl']" => 'true',
   },

--- a/infrastructure/terragrunt/root.hcl
+++ b/infrastructure/terragrunt/root.hcl
@@ -1066,6 +1066,8 @@ locals {
       "pihole-green"    = { domain = "pihole-green.munchbox.cc",    ip = local.traefik_vip }
       "pihole-logan"    = { domain = "pihole-logan.munchbox.cc",    ip = local.traefik_vip }
       "s3"              = { domain = "s3.munchbox.cc",              ip = local.traefik_vip }
+      # --- cinc-server API isn't fronted by Traefik; clients hit the VM directly ---
+      "cinc-server"     = { domain = "cinc-server.munchbox.cc",     ip = "192.168.68.99" }
     }
 
     cname_records = {}


### PR DESCRIPTION
## Summary
- Cert is `CN=cinc-server` with no IP SAN, so connecting via IP fails hostname verification. Pick `cinc-server.munchbox.cc` as the canonical address.
- `root.hcl`: add `cinc-server -> 192.168.68.99` to `pihole_dns_inputs` (direct to the VM, not the Traefik VIP — chef-server API isn't fronted by Traefik).
- `cinc_server` cookbook: default `api_fqdn` now `cinc-server.munchbox.cc` so the next `chef-server-ctl reconfigure` regenerates the cert with the right CN/SAN.

## Test plan (manual, post-merge)
- [ ] `terragrunt apply` under `terragrunt/global/pihole-dns/`
- [ ] `dig +short cinc-server.munchbox.cc @192.168.68.62` returns 192.168.68.99
- [ ] Re-converge `cinc_server::configure` on .99; cert regenerated
- [ ] `knife ssl check` against the FQDN passes

Closes #102