### PR TITLE
GH_ISSUE_104: own the cinc-server cert end-to-end + fix idempotency + CLI quirks

### DIFF
--- a/infrastructure/cinc/cookbooks/cinc_server/attributes/default.rb
+++ b/infrastructure/cinc/cookbooks/cinc_server/attributes/default.rb
@@ -34,6 +34,8 @@ default[cookbook]['install'] = {
 
 default[cookbook]['config'] = {
   'api_fqdn' => 'cinc-server.munchbox.cc',
+  # --- Extra SAN entries (with `DNS:` or `IP:` prefix); api_fqdn is added automatically ---
+  'ssl_alt_names' => [],
   'settings' => {
     "nginx['enable_non_ssl']" => 'true',
   },
@@ -51,14 +53,14 @@ default[cookbook]['config'] = {
 default[cookbook]['bootstrap'] = {
   'org' => {
     'short_name' => 'munchbox',
-    'full_name'  => 'Munchbox',
+    'full_name' => 'Munchbox',
   },
   'user' => {
-    'username'   => 'alex',
+    'username' => 'alex',
     'first_name' => 'Alex',
-    'last_name'  => 'Freidah',
-    'email'      => 'alex.freidah@gmail.com',
-    'password'   => 'CHANGEME-set-via-attribute-override',
-    'key_path'   => '/etc/cinc-bootstrap/alex.pem',
+    'last_name' => 'Freidah',
+    'email' => 'alex.freidah@gmail.com',
+    'password' => 'CHANGEME-set-via-attribute-override',
+    'key_path' => '/etc/cinc-bootstrap/alex.pem',
   },
 }

--- a/infrastructure/cinc/cookbooks/cinc_server/kitchen.yml
+++ b/infrastructure/cinc/cookbooks/cinc_server/kitchen.yml
@@ -46,6 +46,8 @@ suites:
           # api_fqdn must resolve from inside the VM for chef-server-ctl
           # reconfigure to be happy. Use the box's default hostname.
           api_fqdn: cinc-server.test
+          ssl_alt_names:
+            - DNS:cinc-server
           settings:
             "nginx['enable_non_ssl']": 'true'
         bootstrap:

--- a/infrastructure/cinc/cookbooks/cinc_server/recipes/configure.rb
+++ b/infrastructure/cinc/cookbooks/cinc_server/recipes/configure.rb
@@ -9,6 +9,7 @@
 # -------------------------------------------------------------------------------
 
 cinc_server_configure 'cinc-server' do
-  api_fqdn node[cookbook]['config']['api_fqdn']
-  settings node[cookbook]['config']['settings'].to_hash
+  api_fqdn      node[cookbook]['config']['api_fqdn']
+  ssl_alt_names node[cookbook]['config']['ssl_alt_names'].to_a
+  settings      node[cookbook]['config']['settings'].to_hash
 end

--- a/infrastructure/cinc/cookbooks/cinc_server/resources/cinc_server_configure.rb
+++ b/infrastructure/cinc/cookbooks/cinc_server/resources/cinc_server_configure.rb
@@ -4,41 +4,99 @@
 # Cookbook:: cinc_server
 # Resource:: cinc_server_configure
 #
-# Templates /etc/opscode/chef-server.rb and runs `chef-server-ctl
-# reconfigure` whenever the file changes. The reconfigure is a notify
-# (no action :run) so it only fires on real config drift, not every
-# converge.
+# Pins the system hostname to api_fqdn, mints a self-signed TLS cert that
+# the cookbook owns end-to-end, points cinc-server's nginx at that cert
+# (so we control CN + SAN without reaching into cinc-server's own files),
+# templates /etc/opscode/chef-server.rb, and runs `chef-server-ctl
+# reconfigure` whenever any of that changes.
+#
+# We do NOT depend on cinc-server's built-in self-signed cert generator.
+# That generator is "create-once, leave alone" and ignores SAN/CN changes
+# on subsequent reconfigures, which means api_fqdn changes never propagate
+# to the served cert. Owning the cert ourselves fixes that and also lines
+# up cleanly with a future Vault PKI integration -- the only thing that
+# changes is where the cert comes from; the path + nginx wiring stay.
 #
 # Properties:
-#   api_fqdn - The fqdn the server advertises (required).
-#   settings - Hash of `'directive[key]' => value-literal` pairs rendered
-#              verbatim into chef-server.rb. Values must be valid ruby
-#              literals (quote strings, etc.).
+#   api_fqdn      - The fqdn the server advertises (required). Also drives
+#                   the system hostname, the nginx server_name, and the
+#                   cert CN.
+#   ssl_alt_names - Extra SAN entries with `DNS:` or `IP:` prefixes. The
+#                   api_fqdn is added automatically; this is for short
+#                   hostnames, alternate fqdns, or IP SANs (default: []).
+#   settings      - Hash of `'directive[key]' => value-literal` pairs rendered
+#                   verbatim into chef-server.rb. Values must be valid ruby
+#                   literals (quote strings, etc.).
 # -------------------------------------------------------------------------------
 
 unified_mode true
 
 provides :cinc_server_configure
 
-property :api_fqdn, String, required: true
-property :settings, Hash,   default: {}
+property :api_fqdn,      String, required: true
+property :ssl_alt_names, Array,  default: []
+property :settings,      Hash,   default: {}
 
 default_action :configure
 
-# --- Drop chef-server.rb, run reconfigure on change ---
+# --- Pin hostname, own the cert, render chef-server.rb, run reconfigure on change ---
 action :configure do
+  # --- Hostname has to match api_fqdn so anything that defaults to the system hostname (nginx server_name, etc.) is right ---
+  hostname new_resource.api_fqdn
+
+  cert_dir  = '/etc/opscode/certs'
+  cert_path = "#{cert_dir}/#{new_resource.api_fqdn}.crt"
+  key_path  = "#{cert_dir}/#{new_resource.api_fqdn}.key"
+
   directory '/etc/opscode' do
     owner 'root'
     group 'root'
     mode  '0755'
   end
 
+  directory cert_dir do
+    owner 'root'
+    group 'root'
+    mode  '0755'
+  end
+
+  # --- Cookbook-owned self-signed cert. Idempotent on CN + SAN; regenerates only when either changes. ---
+  san_entries = (["DNS:#{new_resource.api_fqdn}"] + new_resource.ssl_alt_names).uniq
+  openssl_x509_certificate cert_path do
+    common_name new_resource.api_fqdn
+    extensions(
+      'subjectAltName' => { 'values' => san_entries, 'critical' => false }
+    )
+    key_file   key_path
+    key_length 2048
+    expire     3650
+    owner      'root'
+    group      'root'
+    mode       '0644'
+    notifies :run, 'execute[chef-server-ctl reconfigure]', :delayed
+  end
+
+  file key_path do
+    owner 'root'
+    group 'root'
+    mode  '0600'
+    only_if { ::File.exist?(key_path) }
+  end
+
+  # --- Derive nginx settings: point at our cert + key, set server_name from api_fqdn ---
+  nginx_derived = {
+    "nginx['server_name']"         => "'#{new_resource.api_fqdn}'",
+    "nginx['ssl_certificate']"     => "'#{cert_path}'",
+    "nginx['ssl_certificate_key']" => "'#{key_path}'",
+  }
+  rendered_settings = new_resource.settings.merge(nginx_derived)
+
   template '/etc/opscode/chef-server.rb' do
     source 'chef-server.rb.erb'
     owner  'root'
     group  'root'
     mode   '0644'
-    variables(api_fqdn: new_resource.api_fqdn, settings: new_resource.settings)
+    variables(api_fqdn: new_resource.api_fqdn, settings: rendered_settings)
     notifies :run, 'execute[chef-server-ctl reconfigure]', :immediately
   end
 
@@ -46,6 +104,14 @@ action :configure do
     command 'chef-server-ctl reconfigure'
     # --- License accept is required since 14.x; harmless on older releases ---
     environment 'CINC_LICENSE' => 'accept', 'CHEF_LICENSE' => 'accept'
+    action :nothing
+    notifies :run, 'execute[wait for cinc-server API ready]', :immediately
+  end
+
+  # --- Block until /_status returns "pong" so downstream bootstrap chef-server-ctl calls don't race a half-up server. Notify-only so it doesn't run on idempotent converges. ---
+  execute 'wait for cinc-server API ready' do
+    command 'for i in $(seq 1 60); do curl -ksf https://localhost/_status | grep -q \'"status":"pong"\' && exit 0; sleep 2; done; exit 1'
+    timeout 130
     action :nothing
   end
 end

--- a/infrastructure/cinc/cookbooks/cinc_server/resources/cinc_server_user.rb
+++ b/infrastructure/cinc/cookbooks/cinc_server/resources/cinc_server_user.rb
@@ -58,12 +58,11 @@ action :create do
     not_if "chef-server-ctl user-show '#{new_resource.username}'"
   end
 
-  # --- Lock down the captured key regardless of how chef-server-ctl wrote it ---
+  # --- Lock down the captured key (manages metadata when file exists; does not create) ---
   file new_resource.key_path do
     owner 'root'
     group 'root'
     mode  '0600'
-    action :touch
     only_if { ::File.exist?(new_resource.key_path) }
   end
 
@@ -71,7 +70,8 @@ action :create do
     execute "chef-server-ctl org-user-add #{new_resource.org} #{new_resource.username} --admin" do
       command "chef-server-ctl org-user-add '#{new_resource.org}' '#{new_resource.username}' --admin"
       environment 'CINC_LICENSE' => 'accept', 'CHEF_LICENSE' => 'accept'
-      not_if "chef-server-ctl org-user-list '#{new_resource.org}' | grep -qx '#{new_resource.username}'"
+      # --- cinc-15.10.91 doesn't accept `org-user-list <org>`; use `user-show --with-orgs` which prints `organizations: <name> <name>...` on one line, then word-match the org name ---
+      not_if "chef-server-ctl user-show '#{new_resource.username}' --with-orgs | grep -E '^organizations:' | grep -wq '#{new_resource.org}'"
     end
   end
 end

--- a/infrastructure/cinc/cookbooks/cinc_server/spec/recipes/bootstrap_spec.rb
+++ b/infrastructure/cinc/cookbooks/cinc_server/spec/recipes/bootstrap_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe 'cinc_server::bootstrap' do
   before do
     stub_command("chef-server-ctl org-show 'munchbox'").and_return(false)
     stub_command("chef-server-ctl user-show 'alex'").and_return(false)
-    stub_command("chef-server-ctl org-user-list 'munchbox' | grep -qx 'alex'").and_return(false)
+    stub_command("chef-server-ctl user-show 'alex' --with-orgs | grep -E '^organizations:' | grep -wq 'munchbox'").and_return(false)
   end
 
   cached(:chef_run) do
@@ -29,9 +29,9 @@ RSpec.describe 'cinc_server::bootstrap' do
     expect(chef_run).to create_cinc_server_user('alex')
       .with(
         first_name: 'Alex',
-        last_name:  'Freidah',
-        email:      'alex.freidah@gmail.com',
-        org:        'munchbox'
+        last_name: 'Freidah',
+        email: 'alex.freidah@gmail.com',
+        org: 'munchbox'
       )
   end
 
@@ -39,5 +39,35 @@ RSpec.describe 'cinc_server::bootstrap' do
   it 'creates the bootstrap key directory with restrictive perms' do
     expect(chef_run).to create_directory('/etc/cinc-bootstrap')
       .with(owner: 'root', group: 'root', mode: '0700')
+  end
+
+  # --- Underlying chef-server-ctl execute resources are queued ---
+  it 'queues the org-create execute (gated by org-show)' do
+    expect(chef_run).to run_execute('chef-server-ctl org-create munchbox')
+  end
+
+  it 'queues the user-create execute (gated by user-show)' do
+    expect(chef_run).to run_execute('chef-server-ctl user-create alex')
+  end
+
+  it 'queues the org-user-add execute to make alex an admin of munchbox' do
+    expect(chef_run).to run_execute('chef-server-ctl org-user-add munchbox alex --admin')
+  end
+
+  # --- Pretend the pem exists post-user-create so the perms-lockdown file resource runs ---
+  context 'when the captured pem exists' do
+    cached(:chef_run_with_pem) do
+      stub_command("chef-server-ctl org-show 'munchbox'").and_return(false)
+      stub_command("chef-server-ctl user-show 'alex'").and_return(false)
+      stub_command("chef-server-ctl user-show 'alex' --with-orgs | grep -E '^organizations:' | grep -wq 'munchbox'").and_return(false)
+      allow(File).to receive(:exist?).and_call_original
+      allow(File).to receive(:exist?).with('/etc/cinc-bootstrap/alex.pem').and_return(true)
+      ChefSpec::SoloRunner.new(step_into: %w(cinc_server_org cinc_server_user)).converge('cinc_server::bootstrap')
+    end
+
+    it 'locks the captured pem down to 0600 root:root' do
+      expect(chef_run_with_pem).to create_file('/etc/cinc-bootstrap/alex.pem')
+        .with(owner: 'root', group: 'root', mode: '0600')
+    end
   end
 end

--- a/infrastructure/cinc/cookbooks/cinc_server/spec/recipes/configure_spec.rb
+++ b/infrastructure/cinc/cookbooks/cinc_server/spec/recipes/configure_spec.rb
@@ -33,4 +33,65 @@ RSpec.describe 'cinc_server::configure' do
     template = chef_run.template('/etc/opscode/chef-server.rb')
     expect(template).to notify('execute[chef-server-ctl reconfigure]').to(:run).immediately
   end
+
+  # --- Hostname is pinned to api_fqdn so the cert CN comes out right ---
+  it 'sets the system hostname to api_fqdn' do
+    expect(chef_run).to set_hostname('cinc-server.munchbox.cc')
+  end
+
+  # --- Template variables derive nginx server_name + point at our cookbook-owned cert ---
+  it 'renders chef-server.rb with derived nginx settings' do
+    template = chef_run.template('/etc/opscode/chef-server.rb')
+    expect(template.variables[:settings]).to include(
+      "nginx['server_name']"         => "'cinc-server.munchbox.cc'",
+      "nginx['ssl_certificate']"     => "'/etc/opscode/certs/cinc-server.munchbox.cc.crt'",
+      "nginx['ssl_certificate_key']" => "'/etc/opscode/certs/cinc-server.munchbox.cc.key'"
+    )
+  end
+
+  # --- /etc/opscode is created with the right perms before the template lands in it ---
+  it 'creates /etc/opscode with 0755 root:root' do
+    expect(chef_run).to create_directory('/etc/opscode')
+      .with(owner: 'root', group: 'root', mode: '0755')
+  end
+
+  # --- We own the cert end-to-end: dedicated dir + openssl_x509_certificate resource + key perms file ---
+  it 'creates /etc/opscode/certs with 0755 root:root' do
+    expect(chef_run).to create_directory('/etc/opscode/certs')
+      .with(owner: 'root', group: 'root', mode: '0755')
+  end
+
+  it 'declares the self-signed cert with CN + SAN derived from api_fqdn' do
+    expect(chef_run).to create_openssl_x509_certificate('/etc/opscode/certs/cinc-server.munchbox.cc.crt')
+      .with(common_name: 'cinc-server.munchbox.cc')
+  end
+
+  it 'notifies a delayed reconfigure when the cert regenerates' do
+    cert = chef_run.openssl_x509_certificate('/etc/opscode/certs/cinc-server.munchbox.cc.crt')
+    expect(cert).to notify('execute[chef-server-ctl reconfigure]').to(:run).delayed
+  end
+
+  # --- API-readiness poll is notify-only; reconfigure fires it after a real config change ---
+  it 'declares the wait-for-API execute as notify-only' do
+    expect(chef_run.execute('wait for cinc-server API ready')).to do_nothing
+  end
+
+  it 'queues an immediate wait when reconfigure fires' do
+    reconfigure = chef_run.execute('chef-server-ctl reconfigure')
+    expect(reconfigure).to notify('execute[wait for cinc-server API ready]').to(:run).immediately
+  end
+
+  # --- Pretend the cert key exists post-cert-gen so the perms-lockdown file resource runs ---
+  context 'when the cert key exists' do
+    cached(:chef_run_with_key) do
+      allow(File).to receive(:exist?).and_call_original
+      allow(File).to receive(:exist?).with('/etc/opscode/certs/cinc-server.munchbox.cc.key').and_return(true)
+      ChefSpec::SoloRunner.new(step_into: %w(cinc_server_configure)).converge('cinc_server::configure')
+    end
+
+    it 'locks the key down to 0600 root:root' do
+      expect(chef_run_with_key).to create_file('/etc/opscode/certs/cinc-server.munchbox.cc.key')
+        .with(owner: 'root', group: 'root', mode: '0600')
+    end
+  end
 end

--- a/infrastructure/cinc/cookbooks/cinc_server/spec/recipes/install_spec.rb
+++ b/infrastructure/cinc/cookbooks/cinc_server/spec/recipes/install_spec.rb
@@ -22,4 +22,15 @@ RSpec.describe 'cinc_server::install' do
     expect(chef_run).to install_dpkg_package('cinc-server-core')
       .with(version: '15.10.91-1')
   end
+
+  # --- cron prereq is installed for /etc/cron.hourly ---
+  it 'installs cron as a prereq' do
+    expect(chef_run).to install_package('cron')
+  end
+
+  # --- The .deb is fetched to a deterministic cache path ---
+  it 'fetches the .deb to /var/cache' do
+    expect(chef_run).to create_remote_file('/var/cache/cinc-server-core-15.10.91.deb')
+      .with(owner: 'root', group: 'root', mode: '0644')
+  end
 end

--- a/infrastructure/cinc/cookbooks/cinc_server/test/integration/default/controls/cinc_server.rb
+++ b/infrastructure/cinc/cookbooks/cinc_server/test/integration/default/controls/cinc_server.rb
@@ -20,16 +20,67 @@ control 'install' do
     it { should exist }
     it { should be_executable }
   end
+
+  # --- cron is a debian-12-cloud-image prereq for infra-server::log_cleanup ---
+  describe package('cron') do
+    it { should be_installed }
+  end
 end
 
 control 'configure' do
   impact 1.0
   title 'cinc_server::configure templates chef-server.rb and reconfigures the server'
 
+  describe directory('/etc/opscode') do
+    it { should exist }
+    its('mode') { should cmp '0755' }
+    its('owner') { should eq 'root' }
+    its('group') { should eq 'root' }
+  end
+
   describe file('/etc/opscode/chef-server.rb') do
     it { should exist }
     its('mode') { should cmp '0644' }
     its('content') { should match(/^api_fqdn 'cinc-server\.test'/) }
+    its('content') { should match(/^nginx\['server_name'\] 'cinc-server\.test'/) }
+    its('content') { should match(%r{^nginx\['ssl_certificate'\] '/etc/opscode/certs/cinc-server\.test\.crt'}) }
+    its('content') { should match(%r{^nginx\['ssl_certificate_key'\] '/etc/opscode/certs/cinc-server\.test\.key'}) }
+    its('content') { should match(/^nginx\['enable_non_ssl'\] true/) }
+  end
+
+  # --- Hostname was set to api_fqdn so anything that defaults to it (e.g. ohai) is right ---
+  describe command('hostname') do
+    its('stdout') { should match(/^cinc-server\.test/) }
+  end
+
+  # --- Cert + key are owned by the cookbook (out of cinc-server's auto-gen tree) ---
+  describe directory('/etc/opscode/certs') do
+    it { should exist }
+    its('mode') { should cmp '0755' }
+    its('owner') { should eq 'root' }
+  end
+
+  describe file('/etc/opscode/certs/cinc-server.test.crt') do
+    it { should exist }
+    its('mode') { should cmp '0644' }
+    its('owner') { should eq 'root' }
+  end
+
+  describe file('/etc/opscode/certs/cinc-server.test.key') do
+    it { should exist }
+    its('mode') { should cmp '0600' }
+    its('owner') { should eq 'root' }
+  end
+
+  describe x509_certificate('/etc/opscode/certs/cinc-server.test.crt') do
+    its('subject.CN') { should eq 'cinc-server.test' }
+    its('subject_alt_names') { should include 'DNS:cinc-server.test' }
+    its('subject_alt_names') { should include 'DNS:cinc-server' }
+  end
+
+  # --- Cert served by nginx on 443 must be the one we own, not cinc-server's auto-cert ---
+  describe command('openssl s_client -connect localhost:443 -servername cinc-server.test </dev/null 2>/dev/null | openssl x509 -noout -subject') do
+    its('stdout') { should match(/CN\s*=\s*cinc-server\.test/) }
   end
 
   # --- Top-level systemd unit that owns the runit supervisor for all
@@ -59,6 +110,13 @@ control 'bootstrap' do
   impact 1.0
   title 'cinc_server::bootstrap creates the initial org + admin user'
 
+  describe directory('/etc/cinc-bootstrap') do
+    it { should exist }
+    its('mode') { should cmp '0700' }
+    its('owner') { should eq 'root' }
+    its('group') { should eq 'root' }
+  end
+
   describe command("chef-server-ctl org-show 'munchbox'") do
     its('exit_status') { should eq 0 }
   end
@@ -75,9 +133,9 @@ control 'bootstrap' do
     its('content') { should match(/BEGIN (RSA )?PRIVATE KEY/) }
   end
 
-  # --- alex should be an admin of the munchbox org ---
-  describe command("chef-server-ctl org-user-list 'munchbox'") do
+  # --- alex should be a member of the munchbox org (cinc-15.10.91 doesn't accept `org-user-list <org>`; use user-show --with-orgs) ---
+  describe command("chef-server-ctl user-show 'alex' --with-orgs") do
     its('exit_status') { should eq 0 }
-    its('stdout') { should match(/^alex$/) }
+    its('stdout') { should match(/^organizations:.*\bmunchbox\b/) }
   end
 end


### PR DESCRIPTION
## Summary
- The cookbook now **owns the self-signed TLS cert** end-to-end (via chef's built-in `openssl_x509_certificate`) and points cinc-server's nginx at it via `nginx['ssl_certificate']` + `nginx['ssl_certificate_key']`. cinc-server may still mint its own cert as a side effect; nginx ignores it because of the overrides.
- Cert path: `/etc/opscode/certs/<fqdn>.{crt,key}`. Idempotent on CN + SAN — regenerates only when `api_fqdn` or `ssl_alt_names` change, then notifies reconfigure → nginx serves the new cert.
- **Future Vault PKI swap is a single-resource change**: same cert path + nginx wiring stay, just swap the cert source.
- Pins the system hostname to `api_fqdn` (chef `hostname` resource) so anything that defaults to the system hostname is right.
- Makes the API-readiness poll notify-only + subscribed to reconfigure (no longer fires on idempotent converges).
- Changes the captured admin pem file resource from `:touch` (not idempotent) to default `:create` (manages perms only when file exists).
- Replaces the broken `chef-server-ctl org-user-list <org>` membership check (cinc-15.10.91 rejects that arg order) with `user-show <user> --with-orgs | grep -wq <org>` in both the resource `not_if` and the matching inspec control.
- Replaces the inspec `ssl(port:443).subject.CN` check (unsupported in this inspec version) with an `openssl s_client | openssl x509 -subject` pipeline.

## Test plan
- [x] `make lint` (cookstyle)
- [x] `make test` — 25/25, 100% chefspec coverage
- [x] `make kitchen` — converge (idempotent on 2nd pass) + verify (all green)

Closes #104