### PR TITLE
GH_ISSUE_106: add cinc_client cookbook

### DIFF
--- a/infrastructure/cinc/cookbooks/cinc_client/.gitignore
+++ b/infrastructure/cinc/cookbooks/cinc_client/.gitignore
@@ -1,0 +1,12 @@
+# --- Test-kitchen state (per-VM logs, vagrant artifacts) ---
+.kitchen/
+kitchen.local.yml
+
+# --- Editor / language-server scratch ---
+.ruby-lsp/
+
+# --- Bundler vendor dir if installed locally ---
+vendor/bundle/
+
+# --- Berkshelf lock file (cookbook dep resolution result) ---
+Berksfile.lock

--- a/infrastructure/cinc/cookbooks/cinc_client/.rubocop.yml
+++ b/infrastructure/cinc/cookbooks/cinc_client/.rubocop.yml
@@ -1,0 +1,30 @@
+# -------------------------------------------------------------------------------
+# Cookstyle (rubocop) config for cinc_client.
+#
+# Inherits cookstyle defaults; project-specific overrides only.
+# -------------------------------------------------------------------------------
+
+require:
+  - cookstyle
+
+inherit_gem:
+  cookstyle: config/cookstyle.yml
+
+AllCops:
+  NewCops: enable
+  TargetRubyVersion: 3.1
+  Exclude:
+    - 'Berksfile.lock'
+    - 'Gemfile.lock'
+    - 'tmp/**/*'
+    - 'vendor/**/*'
+
+# --- Long top-of-file box comments are common; let them be ---
+Layout/LineLength:
+  Max: 120
+
+# --- Specs + inspec controls use long describe blocks; don't fight that ---
+Metrics/BlockLength:
+  Exclude:
+    - 'spec/**/*'
+    - 'test/**/*'

--- a/infrastructure/cinc/cookbooks/cinc_client/Berksfile
+++ b/infrastructure/cinc/cookbooks/cinc_client/Berksfile
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+# -------------------------------------------------------------------------------
+# Berksfile for cinc_client
+#
+# `source chef_repo: '../..'` points at infrastructure/cinc/ so berks finds
+# the sibling cookbooks/ directory (where munchbox_lib lives). `metadata`
+# pulls dep declarations from metadata.rb in this dir.
+# -------------------------------------------------------------------------------
+
+source chef_repo: '../..'
+
+metadata

--- a/infrastructure/cinc/cookbooks/cinc_client/Makefile
+++ b/infrastructure/cinc/cookbooks/cinc_client/Makefile
@@ -1,0 +1,63 @@
+# -------------------------------------------------------------------------------
+# Cookbook:: cinc_client
+# Makefile
+#
+# All targets delegate to cinc-workstation tools wrapped in /usr/local/bin
+# (which env -i to isolate from any RVM/bundler pollution). Bootstrap the
+# toolchain once with `make tools` -- after that everything just works.
+#
+#   make tools    - install cinc-workstation + libvirt/vagrant stack
+#   make lint     - cookstyle
+#   make test     - chefspec/rspec via chef's bundled rspec
+#   make kitchen  - full test-kitchen run (create + converge + verify + destroy)
+#   make verify   - kitchen verify only (VM already up)
+#   make destroy  - tear down the kitchen VM
+# -------------------------------------------------------------------------------
+
+# --- Absolute paths to the cinc wrappers so RVM/rbenv PATH ordering can't win ---
+CHEF      := /usr/local/bin/chef
+COOKSTYLE := /usr/local/bin/cookstyle
+KITCHEN   := /usr/local/bin/kitchen
+
+.PHONY: help tools test lint kitchen create converge verify login destroy
+
+help:
+	@echo "make tools     - install cinc-workstation + libvirt/vagrant stack (one-time host setup)"
+	@echo "make lint      - cookstyle (rubocop with chef cops)"
+	@echo "make test      - chefspec/rspec unit tests"
+	@echo ""
+	@echo "Kitchen lifecycle (run in order, or use 'make kitchen' to do all in one shot):"
+	@echo "  make create    - provision the VM (vagrant up)"
+	@echo "  make converge  - run cinc-client on the VM"
+	@echo "  make verify    - run inspec controls against the converged VM"
+	@echo "  make login     - ssh into the VM"
+	@echo "  make destroy   - tear the VM down"
+	@echo ""
+	@echo "  make kitchen   - create + converge + verify + destroy in one go"
+
+tools:
+	../../scripts/kitchen/debian.sh
+
+lint:
+	$(COOKSTYLE) .
+
+test:
+	$(CHEF) exec rspec spec/
+
+kitchen:
+	$(KITCHEN) test
+
+create:
+	$(KITCHEN) create
+
+converge:
+	$(KITCHEN) converge
+
+verify:
+	$(KITCHEN) verify
+
+login:
+	$(KITCHEN) login
+
+destroy:
+	$(KITCHEN) destroy

--- a/infrastructure/cinc/cookbooks/cinc_client/attributes/default.rb
+++ b/infrastructure/cinc/cookbooks/cinc_client/attributes/default.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+# -------------------------------------------------------------------------------
+# Cookbook:: cinc_client
+# Attributes:: default
+#
+# Defaults for the cinc_client cookbook. Every entry is keyed under the
+# cookbook's namespace via `node[cookbook]`, so renaming the cookbook is
+# a one-line change in metadata.rb.
+# -------------------------------------------------------------------------------
+
+# -------------------------------------------------------------------------------
+# cinc package
+#
+# Pulled from the cinc-project packagecloud apt repo. Pin a known-good
+# version so client upgrades are deliberate, not silent.
+# -------------------------------------------------------------------------------
+
+default[cookbook]['install'] = {
+  'version' => '19.2.12',
+  'package_name' => 'cinc',
+  'apt_repo_uri' => 'https://packagecloud.io/cinc-project/stable/debian/',
+  'apt_repo_key' => 'https://packagecloud.io/cinc-project/stable/gpgkey',
+}
+
+# -------------------------------------------------------------------------------
+# Client configuration
+#
+# `chef_server_url`, `validator_pem`, and `trusted_cert` are the bare
+# minimum for first-run registration. `validator_pem` and `trusted_cert`
+# default to nil -- the operator must override them (eventually via Vault).
+# Without `validator_pem`, the first cinc-client run can't register; the
+# cookbook still drops everything else and the node can be hand-bootstrapped.
+# -------------------------------------------------------------------------------
+
+default[cookbook]['config'] = {
+  'chef_server_url' => 'https://cinc-server.munchbox.cc/organizations/munchbox',
+  'node_name' => nil,
+  'log_level' => 'info',
+  'log_location' => '/var/log/cinc/client.log',
+  'validator_client_name' => 'munchbox-validator',
+  'trusted_cert' => nil,
+  'validator_pem' => nil,
+}
+
+# -------------------------------------------------------------------------------
+# Periodic-run timer
+#
+# Disabled by default so kitchen + first-time provisioning don't try to
+# converge against an unreachable / not-yet-trusted server. Production
+# nodes flip `timer_enabled` to true after first-run registration is
+# verified.
+# -------------------------------------------------------------------------------
+
+default[cookbook]['service'] = {
+  'timer_enabled' => false,
+  'on_calendar' => 'hourly',
+}

--- a/infrastructure/cinc/cookbooks/cinc_client/kitchen.yml
+++ b/infrastructure/cinc/cookbooks/cinc_client/kitchen.yml
@@ -1,0 +1,59 @@
+---
+# -------------------------------------------------------------------------------
+# Test-Kitchen config for cinc_client.
+#
+# Verifies static configuration only: package installed, /etc/cinc/client.rb
+# rendered with the expected content, trusted cert + validator pem dropped
+# at the right perms, systemd units present. Does NOT actually run
+# cinc-client (no reachable cinc-server in the kitchen VM), and the timer
+# is deliberately left disabled so it doesn't fire failing runs in the
+# background.
+# -------------------------------------------------------------------------------
+
+driver:
+  name: vagrant
+  provider: libvirt
+  customize:
+    memory: 1024
+    cpus: 1
+
+provisioner:
+  name: chef_zero
+  product_name: cinc
+  product_version: latest
+  install_strategy: once
+  multiple_converge: 2
+  enforce_idempotency: true
+  chef_license: accept
+  log_level: warn
+
+verifier:
+  name: inspec
+  format: doc
+
+platforms:
+  - name: debian-12
+    driver:
+      box: generic/debian12
+
+suites:
+  - name: default
+    run_list:
+      - recipe[cinc_client::install]
+      - recipe[cinc_client::configure]
+      - recipe[cinc_client::service]
+    attributes:
+      cinc_client:
+        config:
+          chef_server_url: https://cinc-server.test/organizations/munchbox
+          validator_client_name: munchbox-validator
+          # Bogus content for static-config verification only; cinc-client
+          # is never actually run in kitchen.
+          trusted_cert: |
+            -----BEGIN CERTIFICATE-----
+            KITCHEN-TEST-CERT-PLACEHOLDER
+            -----END CERTIFICATE-----
+          validator_pem: |
+            -----BEGIN RSA PRIVATE KEY-----
+            KITCHEN-TEST-VALIDATOR-PLACEHOLDER
+            -----END RSA PRIVATE KEY-----

--- a/infrastructure/cinc/cookbooks/cinc_client/metadata.rb
+++ b/infrastructure/cinc/cookbooks/cinc_client/metadata.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+# -------------------------------------------------------------------------------
+# Cookbook:: cinc_client
+#
+# Project: Munchbox / Author: Alex Freidah
+#
+# Installs and configures cinc-client on a node so it can register with
+# (and pull cookbooks from) the munchbox cinc-server. Includes an
+# opt-in systemd timer for periodic converges.
+# -------------------------------------------------------------------------------
+
+name             'cinc_client'
+maintainer       'Alex Freidah'
+maintainer_email 'alex.freidah@gmail.com'
+license          'MIT'
+description      'Installs and configures cinc-client'
+version          '0.1.0'
+chef_version     '>= 17'
+issues_url       'https://github.com/afreidah/munchbox/issues'
+source_url       'https://github.com/afreidah/munchbox'
+
+depends 'munchbox_lib'
+
+supports 'debian'
+supports 'ubuntu'

--- a/infrastructure/cinc/cookbooks/cinc_client/recipes/configure.rb
+++ b/infrastructure/cinc/cookbooks/cinc_client/recipes/configure.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+# -------------------------------------------------------------------------------
+# Cookbook:: cinc_client
+# Recipe:: configure
+#
+# Drops /etc/cinc/client.rb, the cinc-server trusted cert under
+# /etc/cinc/trusted_certs/, and (if provided) the org validator pem at
+# /etc/cinc/validation.pem so the first cinc-client run can register.
+# -------------------------------------------------------------------------------
+
+cinc_client_configure 'cinc' do
+  chef_server_url       node[cookbook]['config']['chef_server_url']
+  node_name             node[cookbook]['config']['node_name']
+  log_level             node[cookbook]['config']['log_level']
+  log_location          node[cookbook]['config']['log_location']
+  validator_client_name node[cookbook]['config']['validator_client_name']
+  trusted_cert          node[cookbook]['config']['trusted_cert']
+  validator_pem         node[cookbook]['config']['validator_pem']
+end

--- a/infrastructure/cinc/cookbooks/cinc_client/recipes/default.rb
+++ b/infrastructure/cinc/cookbooks/cinc_client/recipes/default.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+# -------------------------------------------------------------------------------
+# Cookbook:: cinc_client
+# Recipe:: default
+#
+# Intentionally empty. Compose by listing the per-concern sub-recipes
+# (`cinc_client::install`, `cinc_client::configure`, `cinc_client::service`)
+# in a role or node run list -- never via `default`.
+# -------------------------------------------------------------------------------

--- a/infrastructure/cinc/cookbooks/cinc_client/recipes/install.rb
+++ b/infrastructure/cinc/cookbooks/cinc_client/recipes/install.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+# -------------------------------------------------------------------------------
+# Cookbook:: cinc_client
+# Recipe:: install
+#
+# Registers the cinc-project apt repo and installs the cinc package at
+# the pinned version.
+# -------------------------------------------------------------------------------
+
+cinc_client_install 'cinc' do
+  version      node[cookbook]['install']['version']
+  package_name node[cookbook]['install']['package_name']
+  apt_repo_uri node[cookbook]['install']['apt_repo_uri']
+  apt_repo_key node[cookbook]['install']['apt_repo_key']
+end

--- a/infrastructure/cinc/cookbooks/cinc_client/recipes/service.rb
+++ b/infrastructure/cinc/cookbooks/cinc_client/recipes/service.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+# -------------------------------------------------------------------------------
+# Cookbook:: cinc_client
+# Recipe:: service
+#
+# Installs the cinc-client.service + cinc-client.timer systemd units and
+# enables/starts the timer iff `service.timer_enabled` is true. Default
+# is disabled so kitchen + initial provisioning don't fire failing runs.
+# -------------------------------------------------------------------------------
+
+cinc_client_service 'cinc' do
+  timer_enabled node[cookbook]['service']['timer_enabled']
+  on_calendar   node[cookbook]['service']['on_calendar']
+end

--- a/infrastructure/cinc/cookbooks/cinc_client/resources/cinc_client_configure.rb
+++ b/infrastructure/cinc/cookbooks/cinc_client/resources/cinc_client_configure.rb
@@ -1,0 +1,101 @@
+# frozen_string_literal: true
+
+# -------------------------------------------------------------------------------
+# Cookbook:: cinc_client
+# Resource:: cinc_client_configure
+#
+# Drops the on-disk state cinc-client needs to talk to a server:
+#   - /etc/cinc/client.rb (rendered)
+#   - /etc/cinc/trusted_certs/cinc-server.crt (if trusted_cert provided)
+#   - /etc/cinc/validation.pem (if validator_pem provided; consumed + can be
+#     hand-deleted after a successful first run)
+#   - /var/log/cinc/ (log_location parent)
+#
+# Properties:
+#   chef_server_url       - Full URL including /organizations/<org> (required).
+#   node_name             - Override the node name; nil = cinc-client uses
+#                           the system hostname (default).
+#   log_level             - cinc log level symbol name (default 'info').
+#   log_location          - Path for cinc-client.log (default /var/log/cinc/client.log).
+#   validator_client_name - Org-level validator client name (required).
+#   trusted_cert          - PEM content of the cinc-server CA cert (nil ok).
+#   validator_pem         - PEM content of the org validator key (nil ok).
+# -------------------------------------------------------------------------------
+
+unified_mode true
+
+provides :cinc_client_configure
+
+property :chef_server_url,       String, required: true
+property :node_name,             [String, nil]
+property :log_level,             String,         default: 'info'
+property :log_location,          String,         default: '/var/log/cinc/client.log'
+property :validator_client_name, String,         required: true
+property :trusted_cert,          [String, nil],  sensitive: true
+property :validator_pem,         [String, nil],  sensitive: true
+
+default_action :configure
+
+# --- Render client.rb + drop trusted cert + (optional) validator pem ---
+action :configure do
+  directory '/etc/cinc' do
+    owner 'root'
+    group 'root'
+    mode  '0755'
+  end
+
+  directory '/etc/cinc/trusted_certs' do
+    owner 'root'
+    group 'root'
+    mode  '0755'
+  end
+
+  directory ::File.dirname(new_resource.log_location) do
+    owner 'root'
+    group 'root'
+    mode  '0755'
+    recursive true
+  end
+
+  if new_resource.trusted_cert
+    file '/etc/cinc/trusted_certs/cinc-server.crt' do
+      content new_resource.trusted_cert
+      owner   'root'
+      group   'root'
+      mode    '0644'
+    end
+  end
+
+  if new_resource.validator_pem
+    file '/etc/cinc/validation.pem' do
+      content   new_resource.validator_pem
+      owner     'root'
+      group     'root'
+      mode      '0600'
+      sensitive true
+    end
+  end
+
+  template '/etc/cinc/client.rb' do
+    source 'client.rb.erb'
+    owner  'root'
+    group  'root'
+    mode   '0644'
+    variables(
+      chef_server_url: new_resource.chef_server_url,
+      node_name: new_resource.node_name,
+      log_level: new_resource.log_level,
+      log_location: new_resource.log_location,
+      validator_client_name: new_resource.validator_client_name
+    )
+  end
+end
+
+# --- Remove rendered config + cached state (does not unregister the node) ---
+action :remove do
+  %w(/etc/cinc/client.rb /etc/cinc/validation.pem /etc/cinc/client.pem /etc/cinc/trusted_certs/cinc-server.crt).each do |path|
+    file path do
+      action :delete
+    end
+  end
+end

--- a/infrastructure/cinc/cookbooks/cinc_client/resources/cinc_client_install.rb
+++ b/infrastructure/cinc/cookbooks/cinc_client/resources/cinc_client_install.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+# -------------------------------------------------------------------------------
+# Cookbook:: cinc_client
+# Resource:: cinc_client_install
+#
+# Registers the cinc-project apt repo and installs the cinc package at
+# the pinned version. Defaults to cinc's packagecloud repo; override
+# uri/key to switch to an internal mirror or chef-io.
+#
+# Properties:
+#   version      - Pinned version, e.g. '19.2.12' (required).
+#   package_name - apt package name (required, e.g. `cinc`).
+#   apt_repo_uri - Base URL of the apt repo (required).
+#   apt_repo_key - URL of the ascii-armoured signing key (required).
+# -------------------------------------------------------------------------------
+
+unified_mode true
+
+provides :cinc_client_install
+
+property :version,      String, required: true
+property :package_name, String, required: true
+property :apt_repo_uri, String, required: true
+property :apt_repo_key, String, required: true
+
+default_action :install
+
+# --- Register cinc-project apt repo + install the cinc package ---
+action :install do
+  # --- Refresh apt cache first; debian-12 cloud images ship with stale indexes that 404 on version-pinned gnupg/apt-transport-https installs ---
+  apt_update 'cinc_client_install' do
+    action :periodic
+  end
+
+  # --- apt_repository shells out to gpg + needs https transport at compile time ---
+  package %w(gnupg apt-transport-https ca-certificates) do
+    action :install
+  end
+
+  apt_repository 'cinc-project' do
+    uri          new_resource.apt_repo_uri
+    components   %w(main)
+    key          new_resource.apt_repo_key
+    action       :add
+  end
+
+  apt_package new_resource.package_name do
+    version "#{new_resource.version}-1"
+    action  :install
+  end
+end
+
+# --- Remove the package; leave the repo registered ---
+action :remove do
+  apt_package new_resource.package_name do
+    action :remove
+  end
+end

--- a/infrastructure/cinc/cookbooks/cinc_client/resources/cinc_client_service.rb
+++ b/infrastructure/cinc/cookbooks/cinc_client/resources/cinc_client_service.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+# -------------------------------------------------------------------------------
+# Cookbook:: cinc_client
+# Resource:: cinc_client_service
+#
+# Installs the cinc-client.service + cinc-client.timer systemd units via
+# chef's built-in `systemd_unit` resource. Daemon-reload fires
+# automatically when content changes (systemd_unit's `triggers_reload`
+# default). Timer enable/start/stop is gated on `timer_enabled` so kitchen
+# + first-time provisioning can keep it stopped while still installing
+# the units; production flips it on after first-run registration is
+# verified.
+#
+# Properties:
+#   timer_enabled - When true, timer is enabled + started; when false, disabled + stopped (required).
+#   on_calendar   - systemd OnCalendar spec (e.g. `hourly`, `*:0/30`) (required).
+# -------------------------------------------------------------------------------
+
+unified_mode true
+
+provides :cinc_client_service
+
+property :timer_enabled, [true, false], required: true
+property :on_calendar,   String,                  required: true
+
+default_action :configure
+
+# --- Install both units, gate timer enable/start on the attribute ---
+action :configure do
+  # --- Oneshot service triggered by the timer; never enabled directly ---
+  systemd_unit 'cinc-client.service' do
+    content <<~UNIT
+      [Unit]
+      Description=Cinc Client periodic run
+      After=network-online.target
+      Wants=network-online.target
+
+      [Service]
+      Type=oneshot
+      ExecStart=/usr/bin/cinc-client
+    UNIT
+    action :create
+  end
+
+  # --- Timer drives the periodic invocation; enabled/started iff opt-in ---
+  systemd_unit 'cinc-client.timer' do
+    content <<~UNIT
+      [Unit]
+      Description=Run cinc-client periodically
+
+      [Timer]
+      OnCalendar=#{new_resource.on_calendar}
+      Persistent=true
+
+      [Install]
+      WantedBy=timers.target
+    UNIT
+    action(new_resource.timer_enabled ? %i(create enable start) : %i(create disable stop))
+  end
+end
+
+# --- Stop + tear down both units ---
+action :remove do
+  systemd_unit 'cinc-client.timer' do
+    action %i(disable stop delete)
+  end
+
+  systemd_unit 'cinc-client.service' do
+    action :delete
+  end
+end

--- a/infrastructure/cinc/cookbooks/cinc_client/spec/recipes/configure_spec.rb
+++ b/infrastructure/cinc/cookbooks/cinc_client/spec/recipes/configure_spec.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+# -------------------------------------------------------------------------------
+# configure recipe spec
+# -------------------------------------------------------------------------------
+
+RSpec.describe 'cinc_client::configure' do
+  cached(:chef_run) do
+    ChefSpec::SoloRunner.new(step_into: %w(cinc_client_configure)).converge('cinc_client::configure')
+  end
+
+  # --- Wrapping resource gets credit for coverage ---
+  it 'declares the cinc_client_configure resource' do
+    expect(chef_run).to configure_cinc_client_configure('cinc')
+  end
+
+  # --- Config + cert + log dirs land with the right perms ---
+  it 'creates /etc/cinc with 0755 root:root' do
+    expect(chef_run).to create_directory('/etc/cinc')
+      .with(owner: 'root', group: 'root', mode: '0755')
+  end
+
+  it 'creates /etc/cinc/trusted_certs with 0755 root:root' do
+    expect(chef_run).to create_directory('/etc/cinc/trusted_certs')
+      .with(owner: 'root', group: 'root', mode: '0755')
+  end
+
+  it 'creates the cinc log dir' do
+    expect(chef_run).to create_directory('/var/log/cinc')
+      .with(owner: 'root', group: 'root', mode: '0755')
+  end
+
+  # --- client.rb is templated with the cinc-server FQDN URL ---
+  it 'templates /etc/cinc/client.rb' do
+    expect(chef_run).to create_template('/etc/cinc/client.rb')
+      .with(owner: 'root', group: 'root', mode: '0644')
+  end
+
+  it 'renders client.rb with the configured chef_server_url' do
+    template = chef_run.template('/etc/cinc/client.rb')
+    expect(template.variables[:chef_server_url])
+      .to eq('https://cinc-server.munchbox.cc/organizations/munchbox')
+  end
+
+  # --- trusted_cert + validator_pem are conditional on attribute values ---
+  context 'when no trusted_cert is provided' do
+    it 'does not drop a cinc-server.crt' do
+      expect(chef_run.find_resource(:file, '/etc/cinc/trusted_certs/cinc-server.crt')).to be_nil
+    end
+  end
+
+  context 'when no validator_pem is provided' do
+    it 'does not drop a validation.pem' do
+      expect(chef_run.find_resource(:file, '/etc/cinc/validation.pem')).to be_nil
+    end
+  end
+
+  context 'when trusted_cert + validator_pem are provided' do
+    cached(:chef_run_with_creds) do
+      ChefSpec::SoloRunner.new(step_into: %w(cinc_client_configure)) do |node|
+        node.override[:cinc_client][:config][:trusted_cert]  = '-- TEST CERT --'
+        node.override[:cinc_client][:config][:validator_pem] = '-- TEST VALIDATOR --'
+      end.converge('cinc_client::configure')
+    end
+
+    it 'drops the cinc-server trusted cert with 0644 perms' do
+      expect(chef_run_with_creds).to create_file('/etc/cinc/trusted_certs/cinc-server.crt')
+        .with(owner: 'root', group: 'root', mode: '0644')
+    end
+
+    it 'drops the validator pem with 0600 perms (sensitive)' do
+      expect(chef_run_with_creds).to create_file('/etc/cinc/validation.pem')
+        .with(owner: 'root', group: 'root', mode: '0600')
+    end
+  end
+end

--- a/infrastructure/cinc/cookbooks/cinc_client/spec/recipes/default_spec.rb
+++ b/infrastructure/cinc/cookbooks/cinc_client/spec/recipes/default_spec.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+# -------------------------------------------------------------------------------
+# default recipe spec -- recipe is intentionally empty so the only assertion
+# is that it loads and converges without declaring any resources.
+# -------------------------------------------------------------------------------
+
+RSpec.describe 'cinc_client::default' do
+  cached(:chef_run) { ChefSpec::SoloRunner.new.converge('cinc_client::default') }
+
+  it 'converges with no resources' do
+    expect(chef_run.resource_collection.to_a).to be_empty
+  end
+end

--- a/infrastructure/cinc/cookbooks/cinc_client/spec/recipes/install_spec.rb
+++ b/infrastructure/cinc/cookbooks/cinc_client/spec/recipes/install_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+# -------------------------------------------------------------------------------
+# install recipe spec
+# -------------------------------------------------------------------------------
+
+RSpec.describe 'cinc_client::install' do
+  cached(:chef_run) do
+    ChefSpec::SoloRunner.new(step_into: %w(cinc_client_install)).converge('cinc_client::install')
+  end
+
+  # --- Wrapping resource gets credit for coverage ---
+  it 'declares the cinc_client_install resource' do
+    expect(chef_run).to install_cinc_client_install('cinc')
+  end
+
+  # --- Underlying apt_repository for cinc-project ---
+  it 'registers the cinc-project apt repo' do
+    expect(chef_run).to add_apt_repository('cinc-project')
+      .with(uri: 'https://packagecloud.io/cinc-project/stable/debian/')
+  end
+
+  # --- Pinned cinc package install ---
+  it 'installs cinc at the pinned version' do
+    expect(chef_run).to install_apt_package('cinc')
+      .with(version: '19.2.12-1')
+  end
+end

--- a/infrastructure/cinc/cookbooks/cinc_client/spec/recipes/service_spec.rb
+++ b/infrastructure/cinc/cookbooks/cinc_client/spec/recipes/service_spec.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+# -------------------------------------------------------------------------------
+# service recipe spec
+# -------------------------------------------------------------------------------
+
+RSpec.describe 'cinc_client::service' do
+  cached(:chef_run) do
+    ChefSpec::SoloRunner.new(step_into: %w(cinc_client_service)).converge('cinc_client::service')
+  end
+
+  # --- Wrapping resource gets credit for coverage ---
+  it 'declares the cinc_client_service resource' do
+    expect(chef_run).to configure_cinc_client_service('cinc')
+  end
+
+  # --- Both systemd units are created ---
+  it 'creates the cinc-client.service unit' do
+    expect(chef_run).to create_systemd_unit('cinc-client.service')
+  end
+
+  it 'creates the cinc-client.timer unit' do
+    expect(chef_run).to create_systemd_unit('cinc-client.timer')
+  end
+
+  # --- Default attribute leaves timer disabled (kitchen default; opt-in in prod) ---
+  context 'with the default timer_enabled = false' do
+    it 'disables and stops the timer' do
+      expect(chef_run).to disable_systemd_unit('cinc-client.timer')
+      expect(chef_run).to stop_systemd_unit('cinc-client.timer')
+    end
+  end
+
+  context 'with timer_enabled = true' do
+    cached(:chef_run_with_timer) do
+      ChefSpec::SoloRunner.new(step_into: %w(cinc_client_service)) do |node|
+        node.override[:cinc_client][:service][:timer_enabled] = true
+      end.converge('cinc_client::service')
+    end
+
+    it 'enables and starts the timer' do
+      expect(chef_run_with_timer).to enable_systemd_unit('cinc-client.timer')
+      expect(chef_run_with_timer).to start_systemd_unit('cinc-client.timer')
+    end
+  end
+end

--- a/infrastructure/cinc/cookbooks/cinc_client/spec/spec_helper.rb
+++ b/infrastructure/cinc/cookbooks/cinc_client/spec/spec_helper.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+# -------------------------------------------------------------------------------
+# Cookbook:: cinc_client
+# Spec helper -- wires up chefspec with our cookbook path so the `cookbook`
+# helper from munchbox_lib resolves correctly when recipes and resources run.
+# -------------------------------------------------------------------------------
+
+require 'chefspec'
+
+# --- Load shared rspec/chefspec matchers (e.g. do_nothing) ---
+Dir[File.expand_path('support/**/*.rb', __dir__)].each { |f| require f }
+
+ChefSpec::Coverage.start! { add_filter 'munchbox_lib' }
+
+RSpec.configure do |config|
+  # --- Point chefspec at this cookbook + munchbox_lib next door ---
+  config.cookbook_path = [
+    File.expand_path('../../', __dir__),
+    File.expand_path('../../../munchbox_lib', __dir__),
+  ]
+
+  config.platform        = 'debian'
+  config.version         = '12'
+  config.log_level       = :error
+  config.disable_monkey_patching!
+  config.order = :random
+  Kernel.srand(config.seed)
+end

--- a/infrastructure/cinc/cookbooks/cinc_client/spec/support/matchers.rb
+++ b/infrastructure/cinc/cookbooks/cinc_client/spec/support/matchers.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+# -------------------------------------------------------------------------------
+# Custom rspec/chefspec matchers
+#
+# ChefSpec's auto-generated matchers call `ChefSpec::Coverage.cover!` on
+# the resource, which is how the coverage tracker decides a resource was
+# tested. Resources declared with `action :nothing` never get hit by an
+# action-named matcher, so they always show up as untouched.
+#
+# `do_nothing` is a thin matcher that calls cover! and asserts the
+# resource's action is :nothing.
+# -------------------------------------------------------------------------------
+
+RSpec::Matchers.define :do_nothing do
+  match do |resource|
+    next false unless resource
+
+    ChefSpec::Coverage.cover!(resource)
+    actions = Array(resource.action)
+    actions.include?(:nothing)
+  end
+
+  failure_message do |resource|
+    if resource.nil?
+      'expected a chef resource but got nil'
+    else
+      "expected #{resource} to have action :nothing, got #{Array(resource.action).inspect}"
+    end
+  end
+end

--- a/infrastructure/cinc/cookbooks/cinc_client/templates/client.rb.erb
+++ b/infrastructure/cinc/cookbooks/cinc_client/templates/client.rb.erb
@@ -1,0 +1,20 @@
+<%#
+  Cookbook:: cinc_client
+  Template:: client.rb.erb
+
+  Rendered at /etc/cinc/client.rb. node_name is omitted when nil so
+  cinc-client falls back to the system hostname automatically.
+%>
+# Managed by chef (cinc_client::configure) -- do not edit by hand.
+
+chef_server_url        '<%= @chef_server_url %>'
+<% if @node_name -%>
+node_name              '<%= @node_name %>'
+<% end -%>
+validation_client_name '<%= @validator_client_name %>'
+validation_key         '/etc/cinc/validation.pem'
+client_key             '/etc/cinc/client.pem'
+trusted_certs_dir      '/etc/cinc/trusted_certs'
+
+log_level    :<%= @log_level %>
+log_location '<%= @log_location %>'

--- a/infrastructure/cinc/cookbooks/cinc_client/test/integration/default/controls/cinc_client.rb
+++ b/infrastructure/cinc/cookbooks/cinc_client/test/integration/default/controls/cinc_client.rb
@@ -1,0 +1,97 @@
+# frozen_string_literal: true
+
+# -------------------------------------------------------------------------------
+# cinc_client integration controls
+#
+# Static-config verification only; cinc-client is never actually run in
+# kitchen (no reachable cinc-server). Asserts package presence, config
+# content, cert + validator drop locations + perms, and systemd unit
+# installation. Timer is expected to be disabled (kitchen default).
+# -------------------------------------------------------------------------------
+
+control 'install' do
+  impact 1.0
+  title 'cinc_client::install installs the cinc package + repo'
+
+  describe package('cinc') do
+    it { should be_installed }
+  end
+
+  describe file('/etc/apt/sources.list.d/cinc-project.list') do
+    it { should exist }
+    its('content') { should match(%r{packagecloud\.io/cinc-project/stable/debian}) }
+  end
+
+  describe file('/usr/bin/cinc-client') do
+    it { should exist }
+    it { should be_executable }
+  end
+end
+
+control 'configure' do
+  impact 1.0
+  title 'cinc_client::configure drops client.rb + trusted cert + validator'
+
+  describe directory('/etc/cinc') do
+    it { should exist }
+    its('mode') { should cmp '0755' }
+    its('owner') { should eq 'root' }
+  end
+
+  describe directory('/etc/cinc/trusted_certs') do
+    it { should exist }
+    its('mode') { should cmp '0755' }
+  end
+
+  describe directory('/var/log/cinc') do
+    it { should exist }
+    its('mode') { should cmp '0755' }
+  end
+
+  describe file('/etc/cinc/client.rb') do
+    it { should exist }
+    its('mode') { should cmp '0644' }
+    its('content') { should match(%r{^chef_server_url\s+'https://cinc-server\.test/organizations/munchbox'$}) }
+    its('content') { should match(/^validation_client_name\s+'munchbox-validator'$/) }
+    its('content') { should match(%r{^client_key\s+'/etc/cinc/client\.pem'$}) }
+    its('content') { should match(%r{^trusted_certs_dir\s+'/etc/cinc/trusted_certs'$}) }
+    its('content') { should match(/^log_level\s+:info$/) }
+  end
+
+  describe file('/etc/cinc/trusted_certs/cinc-server.crt') do
+    it { should exist }
+    its('mode') { should cmp '0644' }
+    its('owner') { should eq 'root' }
+    its('content') { should match(/KITCHEN-TEST-CERT-PLACEHOLDER/) }
+  end
+
+  describe file('/etc/cinc/validation.pem') do
+    it { should exist }
+    its('mode') { should cmp '0600' }
+    its('owner') { should eq 'root' }
+    its('content') { should match(/KITCHEN-TEST-VALIDATOR-PLACEHOLDER/) }
+  end
+end
+
+control 'service' do
+  impact 1.0
+  title 'cinc_client::service installs systemd units; timer disabled by default'
+
+  describe file('/etc/systemd/system/cinc-client.service') do
+    it { should exist }
+    its('content') { should match(%r{^ExecStart=/usr/bin/cinc-client$}) }
+    its('content') { should match(/^Type=oneshot$/) }
+  end
+
+  describe file('/etc/systemd/system/cinc-client.timer') do
+    it { should exist }
+    its('content') { should match(/^OnCalendar=hourly$/) }
+    its('content') { should match(/^Persistent=true$/) }
+  end
+
+  # --- Timer is disabled per kitchen default; flipping the attribute in production enables it ---
+  describe service('cinc-client.timer') do
+    it { should_not be_enabled }
+    it { should_not be_running }
+  end
+end

--- a/infrastructure/cinc/cookbooks/cinc_client/test/integration/default/inspec.yml
+++ b/infrastructure/cinc/cookbooks/cinc_client/test/integration/default/inspec.yml
@@ -1,0 +1,10 @@
+---
+name: cinc_client
+title: cinc_client integration controls
+maintainer: Alex Freidah
+copyright: Alex Freidah
+license: MIT
+summary: Validates a converged cinc_client node (package + config + systemd units).
+version: 0.1.0
+supports:
+  - platform: debian


### PR DESCRIPTION
## Summary
- Installs cinc-client + drops its config so a node can register with the munchbox cinc-server and converge on a schedule. Fourth cookbook of the chef migration (#81).
- Layout matches `munchbox_base` / `cinc_server`: targeted resource per concern, one recipe per resource, `default.rb` empty.
- `cinc_client::install` — cinc-project packagecloud apt repo + cinc package pin (plus apt-update so debian-12 cloud images don't 404 on point-release drift).
- `cinc_client::configure` — `/etc/cinc/client.rb`, trusted cert, conditional validator pem for first-run registration.
- `cinc_client::service` — `cinc-client.service` + `cinc-client.timer` via the built-in `systemd_unit` resource. Timer enable/start gated on `service.timer_enabled` (default false; kitchen + initial provisioning don't fire failing runs).
- Default `chef_server_url` points at the cinc-server FQDN (`https://cinc-server.munchbox.cc/organizations/munchbox`).

## Test plan
- [x] `make lint` (cookstyle)
- [x] `make test` — 19 examples, 0 failures
- [x] `make verify` — green (static-config: package, client.rb content, cert + validator perms, systemd units installed, timer disabled by default)

## Known follow-ups
- Vault-backed `trusted_cert` + `validator_pem` instead of plaintext attribute (mirror of #100).
- Per-cookbook kitchen suite naming so libvirt domains don't collide (separate PR).

Closes #106