### PR TITLE
Chef: bring all cookbooks up to munchbox_base testing standard

### DIFF
--- a/infrastructure/cinc/cookbooks/cni/.gitignore
+++ b/infrastructure/cinc/cookbooks/cni/.gitignore
@@ -1,0 +1,5 @@
+.kitchen/
+kitchen.local.yml
+.ruby-lsp/
+vendor/bundle/
+Berksfile.lock

--- a/infrastructure/cinc/cookbooks/cni/.rubocop.yml
+++ b/infrastructure/cinc/cookbooks/cni/.rubocop.yml
@@ -1,0 +1,26 @@
+# -------------------------------------------------------------------------------
+# Cookstyle (rubocop) config for cni.
+# -------------------------------------------------------------------------------
+
+require:
+  - cookstyle
+
+inherit_gem:
+  cookstyle: config/cookstyle.yml
+
+AllCops:
+  NewCops: enable
+  TargetRubyVersion: 3.1
+  Exclude:
+    - 'Berksfile.lock'
+    - 'Gemfile.lock'
+    - 'tmp/**/*'
+    - 'vendor/**/*'
+
+Layout/LineLength:
+  Max: 120
+
+Metrics/BlockLength:
+  Exclude:
+    - 'spec/**/*'
+    - 'test/**/*'

--- a/infrastructure/cinc/cookbooks/cni/Berksfile
+++ b/infrastructure/cinc/cookbooks/cni/Berksfile
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+source chef_repo: '../..'
+
+metadata

--- a/infrastructure/cinc/cookbooks/cni/Makefile
+++ b/infrastructure/cinc/cookbooks/cni/Makefile
@@ -1,0 +1,50 @@
+# -------------------------------------------------------------------------------
+# Cookbook:: cni
+# Makefile -- delegates to cinc-workstation tools.
+# -------------------------------------------------------------------------------
+
+CHEF      := /usr/local/bin/chef
+COOKSTYLE := /usr/local/bin/cookstyle
+KITCHEN   := /usr/local/bin/kitchen
+
+.PHONY: help tools test lint kitchen create converge verify login destroy
+
+help:
+	@echo "make tools     - install cinc-workstation + libvirt/vagrant stack (one-time host setup)"
+	@echo "make lint      - cookstyle (rubocop with chef cops)"
+	@echo "make test      - chefspec/rspec unit tests"
+	@echo ""
+	@echo "Kitchen lifecycle:"
+	@echo "  make create    - provision the VM"
+	@echo "  make converge  - run cinc-client on the VM"
+	@echo "  make verify    - run inspec controls against the converged VM"
+	@echo "  make login     - ssh into the VM"
+	@echo "  make destroy   - tear the VM down"
+	@echo "  make kitchen   - create + converge + verify + destroy in one go"
+
+tools:
+	../../scripts/kitchen/debian.sh
+
+lint:
+	$(COOKSTYLE) .
+
+test:
+	$(CHEF) exec rspec spec/
+
+kitchen:
+	$(KITCHEN) test
+
+create:
+	$(KITCHEN) create
+
+converge:
+	$(KITCHEN) converge
+
+verify:
+	$(KITCHEN) verify
+
+login:
+	$(KITCHEN) login
+
+destroy:
+	$(KITCHEN) destroy

--- a/infrastructure/cinc/cookbooks/cni/README.md
+++ b/infrastructure/cinc/cookbooks/cni/README.md
@@ -1,0 +1,18 @@
+# cni
+
+Installs the containernetworking/plugins CNI binaries under `/opt/cni/bin`. Required for Nomad bridge networking and Consul Connect on every nomad server + client.
+
+## Recipes
+
+| Recipe | Purpose |
+|---|---|
+| `default` | Empty; opt in via run_list. |
+| `install` | Downloads + extracts the plugins tarball; arch-aware (amd64 / arm64). |
+
+## Testing
+
+```
+make lint
+make test
+make kitchen     # full converge+verify cycle in a debian-12 libvirt VM
+```

--- a/infrastructure/cinc/cookbooks/cni/attributes/default.rb
+++ b/infrastructure/cinc/cookbooks/cni/attributes/default.rb
@@ -7,7 +7,7 @@
 cookbook = 'cni'
 
 default[cookbook]['install'] = {
-  version:     '1.4.0',
+  version: '1.4.0',
   install_dir: '/opt/cni/bin',
   release_url: 'https://github.com/containernetworking/plugins/releases/download',
 }

--- a/infrastructure/cinc/cookbooks/cni/kitchen.yml
+++ b/infrastructure/cinc/cookbooks/cni/kitchen.yml
@@ -1,0 +1,40 @@
+---
+# -------------------------------------------------------------------------------
+# Test-Kitchen config for cni.
+#
+# Single suite: downloads the CNI plugins tarball + extracts under /opt/cni/bin.
+# -------------------------------------------------------------------------------
+
+driver:
+  name: vagrant
+  provider: libvirt
+  customize:
+    memory: 512
+    cpus: 1
+
+provisioner:
+  name: chef_zero
+  product_name: cinc
+  product_version: latest
+  install_strategy: once
+  multiple_converge: 2
+  enforce_idempotency: true
+  chef_license: accept
+  log_level: warn
+
+verifier:
+  name: inspec
+  format: doc
+
+platforms:
+  - name: debian-12
+    driver:
+      box: generic/debian12
+
+suites:
+  - name: default
+    run_list:
+      - recipe[cni::install]
+    verifier:
+      inspec_tests:
+        - test/integration/default

--- a/infrastructure/cinc/cookbooks/cni/spec/recipes/default_spec.rb
+++ b/infrastructure/cinc/cookbooks/cni/spec/recipes/default_spec.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+# -------------------------------------------------------------------------------
+# default recipe spec -- intentionally empty; opt in via role.
+# -------------------------------------------------------------------------------
+
+RSpec.describe 'cni::default' do
+  cached(:chef_run) { ChefSpec::SoloRunner.new.converge(described_recipe) }
+
+  it 'converges without declaring any resources' do
+    expect(chef_run.resource_collection.map(&:to_s)).to be_empty
+  end
+end

--- a/infrastructure/cinc/cookbooks/cni/spec/recipes/install_spec.rb
+++ b/infrastructure/cinc/cookbooks/cni/spec/recipes/install_spec.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+# -------------------------------------------------------------------------------
+# install recipe spec -- steps into cni_install so the underlying
+# directory/execute/file resources are covered.
+# -------------------------------------------------------------------------------
+
+RSpec.describe 'cni::install' do
+  cached(:chef_run) do
+    # --- pretend /opt/cni/bin/.cni-version is absent so the install path runs ---
+    allow(::File).to receive(:exist?).and_call_original
+    allow(::File).to receive(:exist?).with('/opt/cni/bin/.cni-version').and_return(false)
+    allow(::File).to receive(:directory?).and_call_original
+    allow(::File).to receive(:directory?).with('/opt/cni/bin').and_return(false)
+    ChefSpec::SoloRunner.new(step_into: %w(cni_install)).converge(described_recipe)
+  end
+
+  it 'declares the cni_install resource' do
+    expect(chef_run).to install_cni_install('baseline')
+      .with(version: '1.4.0', install_dir: '/opt/cni/bin')
+  end
+
+  it 'creates /opt/cni/bin root:root 0755' do
+    expect(chef_run).to create_directory('/opt/cni/bin')
+      .with(owner: 'root', group: 'root', mode: '0755')
+  end
+
+  it 'downloads the plugins tarball for the active arch' do
+    arch = (RbConfig::CONFIG['host_cpu'] == 'aarch64' ? 'arm64' : 'amd64')
+    expect(chef_run).to run_execute('download cni plugins v1.4.0')
+      .with(command: include("cni-plugins-linux-#{arch}-v1.4.0.tgz"))
+  end
+
+  it 'extracts the tarball into the install dir' do
+    expect(chef_run).to run_execute('extract cni plugins v1.4.0')
+      .with(command: include('tar -xzf'))
+  end
+
+  it 'writes the version stamp file' do
+    expect(chef_run).to create_file('/opt/cni/bin/.cni-version')
+      .with(content: "v1.4.0\n", owner: 'root', group: 'root', mode: '0644')
+  end
+
+  it 'cleans up the downloaded tarball' do
+    arch = (RbConfig::CONFIG['host_cpu'] == 'aarch64' ? 'arm64' : 'amd64')
+    expect(chef_run).to delete_file("/tmp/cni-plugins-linux-#{arch}-v1.4.0.tgz")
+  end
+
+  context 'when /opt/cni/bin/.cni-version already records the requested version' do
+    cached(:idempotent_run) do
+      allow(::File).to receive(:exist?).and_call_original
+      allow(::File).to receive(:exist?).with('/opt/cni/bin/.cni-version').and_return(true)
+      allow(::File).to receive(:read).and_call_original
+      allow(::File).to receive(:read).with('/opt/cni/bin/.cni-version').and_return("v1.4.0\n")
+      allow(::File).to receive(:directory?).and_call_original
+      allow(::File).to receive(:directory?).with('/opt/cni/bin').and_return(true)
+      ChefSpec::SoloRunner.new(step_into: %w(cni_install)).converge(described_recipe)
+    end
+
+    it 'skips the download execute resource' do
+      expect(idempotent_run.find_resources(:execute).map(&:name)).not_to include('download cni plugins v1.4.0')
+    end
+
+    it 'skips the extract execute resource' do
+      expect(idempotent_run.find_resources(:execute).map(&:name)).not_to include('extract cni plugins v1.4.0')
+    end
+  end
+end

--- a/infrastructure/cinc/cookbooks/cni/spec/spec_helper.rb
+++ b/infrastructure/cinc/cookbooks/cni/spec/spec_helper.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+# -------------------------------------------------------------------------------
+# Cookbook:: cni
+# Spec helper.
+# -------------------------------------------------------------------------------
+
+require 'chefspec'
+
+Dir[File.expand_path('support/**/*.rb', __dir__)].each { |f| require f }
+
+ChefSpec::Coverage.start! { add_filter 'munchbox_lib' }
+
+RSpec.configure do |config|
+  config.cookbook_path = [File.expand_path('../../', __dir__)]
+  config.platform        = 'debian'
+  config.version         = '12'
+  config.log_level       = :error
+  config.disable_monkey_patching!
+  config.order = :random
+  Kernel.srand(config.seed)
+end

--- a/infrastructure/cinc/cookbooks/cni/spec/support/matchers.rb
+++ b/infrastructure/cinc/cookbooks/cni/spec/support/matchers.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+# -------------------------------------------------------------------------------
+# Custom rspec/chefspec matchers.
+# -------------------------------------------------------------------------------
+
+RSpec::Matchers.define :do_nothing do
+  match do |resource|
+    next false unless resource
+
+    ChefSpec::Coverage.cover!(resource)
+    actions = Array(resource.action)
+    actions.include?(:nothing)
+  end
+
+  failure_message do |resource|
+    if resource.nil?
+      'expected a chef resource but got nil'
+    else
+      "expected #{resource} to have action :nothing, got #{Array(resource.action).inspect}"
+    end
+  end
+end

--- a/infrastructure/cinc/cookbooks/cni/test/integration/default/controls/cni.rb
+++ b/infrastructure/cinc/cookbooks/cni/test/integration/default/controls/cni.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+# -------------------------------------------------------------------------------
+# cni::install integration controls.
+# -------------------------------------------------------------------------------
+
+control 'cni-install-dir' do
+  impact 1.0
+  title '/opt/cni/bin exists root:root 0755'
+
+  describe directory('/opt/cni/bin') do
+    it { should exist }
+    its('owner') { should eq 'root' }
+    its('group') { should eq 'root' }
+    its('mode')  { should cmp '0755' }
+  end
+end
+
+control 'cni-plugins-present' do
+  impact 1.0
+  title 'expected CNI plugin binaries are installed + executable'
+
+  %w(loopback bridge host-local portmap).each do |plugin|
+    describe file("/opt/cni/bin/#{plugin}") do
+      it { should exist }
+      it { should be_executable }
+    end
+  end
+end
+
+control 'cni-version-stamp' do
+  impact 1.0
+  title '/opt/cni/bin/.cni-version records the installed version'
+
+  describe file('/opt/cni/bin/.cni-version') do
+    it { should exist }
+    its('content') { should match(/^v1\.4\.0/) }
+  end
+end

--- a/infrastructure/cinc/cookbooks/cni/test/integration/default/inspec.yml
+++ b/infrastructure/cinc/cookbooks/cni/test/integration/default/inspec.yml
@@ -1,0 +1,10 @@
+---
+name: cni
+title: cni integration controls
+maintainer: Alex Freidah
+copyright: Alex Freidah
+license: MIT
+summary: Validates a converged cni::install -- plugin binaries under /opt/cni/bin.
+version: 0.1.0
+supports:
+  - platform: debian

--- a/infrastructure/cinc/cookbooks/consul/resources/consul_dns.rb
+++ b/infrastructure/cinc/cookbooks/consul/resources/consul_dns.rb
@@ -95,14 +95,14 @@ action :configure do
     group 'root'
     mode  '0644'
     variables(
-      listen_address:  new_resource.listen_address,
-      host_ip:         new_resource.host_ip,
+      listen_address: new_resource.listen_address,
+      host_ip: new_resource.host_ip,
       consul_dns_port: new_resource.consul_dns_port,
-      coredns_port:    new_resource.coredns_port,
-      pihole_servers:  new_resource.pihole_servers,
-      cache_size:      new_resource.cache_size,
+      coredns_port: new_resource.coredns_port,
+      pihole_servers: new_resource.pihole_servers,
+      cache_size: new_resource.cache_size,
       dns_forward_max: new_resource.dns_forward_max,
-      filter_aaaa:     new_resource.filter_aaaa
+      filter_aaaa: new_resource.filter_aaaa
     )
     notifies :restart, 'service[dnsmasq]', :delayed
   end
@@ -118,7 +118,7 @@ action :configure do
       mode  '0644'
       variables(
         listen_address: new_resource.listen_address,
-        search:         new_resource.resolv_conf_search
+        search: new_resource.resolv_conf_search
       )
     end
   end

--- a/infrastructure/cinc/cookbooks/consul/spec/recipes/configure_spec.rb
+++ b/infrastructure/cinc/cookbooks/consul/spec/recipes/configure_spec.rb
@@ -52,16 +52,16 @@ RSpec.describe 'consul::configure' do
     end
 
     # --- Systemd unit lifecycle ---
-    it 'installs + enables + starts the consul.service systemd unit' do
-      expect(chef_run).to create_systemd_unit('consul.service')
-      expect(chef_run).to enable_systemd_unit('consul.service')
-      expect(chef_run).to start_systemd_unit('consul.service')
+    # --- systemd_unit is rendered by consul_install (static plumbing); configure only enables + starts the service ---
+    it 'enables + starts the consul service' do
+      expect(chef_run).to enable_service('consul')
+      expect(chef_run).to start_service('consul')
     end
 
     # --- Restart notification on config drift ---
-    it 'restarts consul.service when consul.hcl changes (delayed)' do
+    it 'restarts consul (delayed) when consul.hcl changes' do
       expect(chef_run.template('/etc/consul.d/consul.hcl'))
-        .to notify('systemd_unit[consul.service]').to(:restart).delayed
+        .to notify('service[consul]').to(:restart).delayed
     end
   end
 

--- a/infrastructure/cinc/cookbooks/consul/spec/recipes/dns_spec.rb
+++ b/infrastructure/cinc/cookbooks/consul/spec/recipes/dns_spec.rb
@@ -11,10 +11,12 @@ require 'spec_helper'
 # -------------------------------------------------------------------------------
 
 RSpec.describe 'consul::dns' do
-  context 'with defaults (oracle-ish: ipaddress derived)' do
+  context 'with defaults (oracle-ish: ipaddress derived) + manage_resolv_conf on' do
     cached(:chef_run) do
       ChefSpec::SoloRunner.new(step_into: %w(consul_dns)) do |node|
         node.automatic[:ipaddress] = '10.200.0.14'
+        # --- attribute default is now false (per-node opt-in); flip on to exercise the template ---
+        node.normal['consul']['dns']['manage_resolv_conf'] = true
       end.converge('consul::dns')
     end
 
@@ -26,6 +28,10 @@ RSpec.describe 'consul::dns' do
     # --- dnsmasq installed, conflicting services stopped ---
     it 'installs dnsmasq' do
       expect(chef_run).to install_apt_package('dnsmasq')
+    end
+
+    it 'waits for the apt lock before installing dnsmasq' do
+      expect(chef_run).to wait_munchbox_base_apt_lock_wait('consul_dns_install')
     end
 
     it 'stops and disables systemd-resolved' do
@@ -51,8 +57,10 @@ RSpec.describe 'consul::dns' do
         .to notify('service[dnsmasq]').to(:restart).delayed
     end
 
-    # --- /etc/resolv.conf takeover is on by default ---
+    # --- /etc/resolv.conf takeover (manage_resolv_conf overridden true above) ---
     it 'renders /etc/resolv.conf pointing at the loopback dnsmasq listener' do
+      expect(chef_run).to create_template('/etc/resolv.conf')
+        .with(owner: 'root', group: 'root', mode: '0644')
       tpl = chef_run.template('/etc/resolv.conf')
       expect(tpl.variables[:listen_address]).to eq('127.0.0.53')
       expect(tpl.variables[:search]).to eq('munchbox.cc')

--- a/infrastructure/cinc/cookbooks/consul/spec/recipes/install_spec.rb
+++ b/infrastructure/cinc/cookbooks/consul/spec/recipes/install_spec.rb
@@ -48,4 +48,18 @@ RSpec.describe 'consul::install' do
   it 'installs unzip' do
     expect(chef_run).to install_package('unzip')
   end
+
+  it 'fetches the consul release archive' do
+    expect(chef_run).to create_remote_file(%r{/tmp/consul_.+_linux_.+\.zip})
+  end
+
+  it 'installs the consul binary via the install execute resource' do
+    matched = chef_run.find_resources(:execute).find { |r| r.name.start_with?('install consul ') }
+    expect(matched).not_to be_nil
+    ChefSpec::Coverage.cover!(matched)
+  end
+
+  it 'creates the consul.service systemd unit' do
+    expect(chef_run).to create_systemd_unit('consul.service')
+  end
 end

--- a/infrastructure/cinc/cookbooks/docker/.rubocop.yml
+++ b/infrastructure/cinc/cookbooks/docker/.rubocop.yml
@@ -1,0 +1,26 @@
+# -------------------------------------------------------------------------------
+# Cookstyle (rubocop) config for docker.
+# -------------------------------------------------------------------------------
+
+require:
+  - cookstyle
+
+inherit_gem:
+  cookstyle: config/cookstyle.yml
+
+AllCops:
+  NewCops: enable
+  TargetRubyVersion: 3.1
+  Exclude:
+    - 'Berksfile.lock'
+    - 'Gemfile.lock'
+    - 'tmp/**/*'
+    - 'vendor/**/*'
+
+Layout/LineLength:
+  Max: 120
+
+Metrics/BlockLength:
+  Exclude:
+    - 'spec/**/*'
+    - 'test/**/*'

--- a/infrastructure/cinc/cookbooks/docker/spec/recipes/configure_spec.rb
+++ b/infrastructure/cinc/cookbooks/docker/spec/recipes/configure_spec.rb
@@ -22,6 +22,10 @@ RSpec.describe 'docker::configure' do
       expect(chef_run).to configure_docker_configure('daemon')
     end
 
+    it 'creates /etc/docker (where daemon.json lives)' do
+      expect(chef_run).to create_directory('/etc/docker')
+    end
+
     # --- Template lands with the right perms ---
     it 'renders /etc/docker/daemon.json 0644 root:root' do
       expect(chef_run).to create_template('/etc/docker/daemon.json')
@@ -33,10 +37,12 @@ RSpec.describe 'docker::configure' do
       tpl = chef_run.template('/etc/docker/daemon.json')
       cfg = tpl.variables[:config]
       expect(cfg['dns']).to eq(['10.200.0.13'])
-      expect(cfg['dns-search']).to eq(['.'])
+      # --- dns_search defaults to nil in attributes (recipe passes nil), so the resource skips the key entirely ---
+      expect(cfg).not_to have_key('dns-search')
       expect(cfg['log-driver']).to eq('json-file')
       expect(cfg['log-opts']).to eq('max-file' => '3', 'max-size' => '10m')
-      expect(cfg['storage-driver']).to eq('overlay2')
+      # --- storage_driver default intentionally not set in attributes (would break overlayfs nodes); recipe passes nil → resource skips ---
+      expect(cfg).not_to have_key('storage-driver')
     end
 
     # --- daemon.json change triggers a docker restart ---

--- a/infrastructure/cinc/cookbooks/docker/spec/recipes/default_spec.rb
+++ b/infrastructure/cinc/cookbooks/docker/spec/recipes/default_spec.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+# -------------------------------------------------------------------------------
+# default recipe spec -- intentionally empty; opt in via role.
+# -------------------------------------------------------------------------------
+
+RSpec.describe 'docker::default' do
+  cached(:chef_run) { ChefSpec::SoloRunner.new.converge(described_recipe) }
+
+  it 'converges without declaring any resources' do
+    expect(chef_run.resource_collection.map(&:to_s)).to be_empty
+  end
+end

--- a/infrastructure/cinc/cookbooks/docker/spec/recipes/install_spec.rb
+++ b/infrastructure/cinc/cookbooks/docker/spec/recipes/install_spec.rb
@@ -10,6 +10,12 @@ require 'spec_helper'
 # -------------------------------------------------------------------------------
 
 RSpec.describe 'docker::install' do
+  before do
+    # --- resource reads /etc/os-release for VERSION_CODENAME (greenfield-safe). Stub for determinism. ---
+    allow(::File).to receive(:read).and_call_original
+    allow(::File).to receive(:read).with('/etc/os-release').and_return("VERSION_CODENAME=bookworm\n")
+  end
+
   cached(:chef_run) do
     ChefSpec::SoloRunner.new(step_into: %w(docker_install)) do |node|
       node.automatic[:lsb][:codename]   = 'bookworm'
@@ -68,6 +74,15 @@ RSpec.describe 'docker::install' do
     expect(chef_run.group('docker'))
       .to notify('service[nomad]').to(:restart).delayed
   end
+
+  it 'waits for the apt lock around prereqs + packages' do
+    expect(chef_run).to wait_munchbox_base_apt_lock_wait('docker_install_prereqs')
+    expect(chef_run).to wait_munchbox_base_apt_lock_wait('docker_install_packages')
+  end
+
+  it 'adds the docker apt repository (action :add)' do
+    expect(chef_run).to add_apt_repository('docker')
+  end
 end
 
 # -------------------------------------------------------------------------------
@@ -98,6 +113,11 @@ end
 # -------------------------------------------------------------------------------
 
 RSpec.describe 'docker::install on amd64' do
+  before do
+    allow(::File).to receive(:read).and_call_original
+    allow(::File).to receive(:read).with('/etc/os-release').and_return("VERSION_CODENAME=bookworm\n")
+  end
+
   cached(:chef_run) do
     ChefSpec::SoloRunner.new(step_into: %w(docker_install)) do |node|
       node.automatic[:lsb][:codename]   = 'bookworm'
@@ -116,6 +136,11 @@ end
 # -------------------------------------------------------------------------------
 
 RSpec.describe 'docker::install on ubuntu noble' do
+  before do
+    allow(::File).to receive(:read).and_call_original
+    allow(::File).to receive(:read).with('/etc/os-release').and_return("VERSION_CODENAME=noble\n")
+  end
+
   cached(:chef_run) do
     ChefSpec::SoloRunner.new(step_into: %w(docker_install)) do |node|
       node.automatic[:lsb][:codename]   = 'noble'

--- a/infrastructure/cinc/cookbooks/nfs/.gitignore
+++ b/infrastructure/cinc/cookbooks/nfs/.gitignore
@@ -1,0 +1,5 @@
+.kitchen/
+kitchen.local.yml
+.ruby-lsp/
+vendor/bundle/
+Berksfile.lock

--- a/infrastructure/cinc/cookbooks/nfs/.rubocop.yml
+++ b/infrastructure/cinc/cookbooks/nfs/.rubocop.yml
@@ -1,0 +1,26 @@
+# -------------------------------------------------------------------------------
+# Cookstyle (rubocop) config for nfs.
+# -------------------------------------------------------------------------------
+
+require:
+  - cookstyle
+
+inherit_gem:
+  cookstyle: config/cookstyle.yml
+
+AllCops:
+  NewCops: enable
+  TargetRubyVersion: 3.1
+  Exclude:
+    - 'Berksfile.lock'
+    - 'Gemfile.lock'
+    - 'tmp/**/*'
+    - 'vendor/**/*'
+
+Layout/LineLength:
+  Max: 120
+
+Metrics/BlockLength:
+  Exclude:
+    - 'spec/**/*'
+    - 'test/**/*'

--- a/infrastructure/cinc/cookbooks/nfs/Berksfile
+++ b/infrastructure/cinc/cookbooks/nfs/Berksfile
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+source chef_repo: '../..'
+
+metadata

--- a/infrastructure/cinc/cookbooks/nfs/Makefile
+++ b/infrastructure/cinc/cookbooks/nfs/Makefile
@@ -1,0 +1,46 @@
+# -------------------------------------------------------------------------------
+# Cookbook:: nfs
+# Makefile -- delegates to cinc-workstation tools.
+# -------------------------------------------------------------------------------
+
+CHEF      := /usr/local/bin/chef
+COOKSTYLE := /usr/local/bin/cookstyle
+KITCHEN   := /usr/local/bin/kitchen
+
+.PHONY: help tools test lint kitchen create converge verify login destroy
+
+help:
+	@echo "make tools     - install cinc-workstation + libvirt/vagrant stack (one-time host setup)"
+	@echo "make lint      - cookstyle"
+	@echo "make test      - chefspec/rspec unit tests"
+	@echo ""
+	@echo "Kitchen lifecycle:"
+	@echo "  make create / converge / verify / login / destroy"
+	@echo "  make kitchen   - create + converge + verify + destroy in one go"
+
+tools:
+	../../scripts/kitchen/debian.sh
+
+lint:
+	$(COOKSTYLE) .
+
+test:
+	$(CHEF) exec rspec spec/
+
+kitchen:
+	$(KITCHEN) test
+
+create:
+	$(KITCHEN) create
+
+converge:
+	$(KITCHEN) converge
+
+verify:
+	$(KITCHEN) verify
+
+login:
+	$(KITCHEN) login
+
+destroy:
+	$(KITCHEN) destroy

--- a/infrastructure/cinc/cookbooks/nfs/README.md
+++ b/infrastructure/cinc/cookbooks/nfs/README.md
@@ -1,0 +1,23 @@
+# nfs
+
+NFS client install + reusable `nfs_mount` resource, plus a server-side recipe for nodes that export shares (mccoy, rubirosa today).
+
+## Recipes
+
+| Recipe | Purpose |
+|---|---|
+| `default` | Empty; opt in via role. |
+| `client` | `nfs-common` + materializes every entry in `node['nfs']['client']['mounts']` (and `extra_mounts`) via `nfs_mount`. |
+| `server` | `nfs-kernel-server` + renders `/etc/exports` from `node['nfs']['server']['exports']`; empty list = no-op. |
+
+## Testing
+
+```
+make lint
+make test
+make kitchen
+```
+
+The `client` kitchen suite intentionally has empty mounts: a kitchen guest can't reach a real NFS peer, so the suite only proves package install + mount-point dir shape. Real mount/unmount paths are covered by chefspec via attribute overrides.
+
+The `server` suite installs `nfs-kernel-server`, renders `/etc/exports` with a 127.0.0.0/8 export of `/srv/nfs/test`, and runs `exportfs -ra`. Inspec verifies `/etc/exports` contents + service state.

--- a/infrastructure/cinc/cookbooks/nfs/attributes/default.rb
+++ b/infrastructure/cinc/cookbooks/nfs/attributes/default.rb
@@ -21,8 +21,8 @@ default[cookbook]['client'] = {
 
 # --- Server side. exports = list of hashes {path:, clients:, options:}; empty = recipe is a no-op. mccoy + rubirosa are the only consumers today. ---
 default[cookbook]['server'] = {
-  package:      'nfs-kernel-server',
+  package: 'nfs-kernel-server',
   service_name: 'nfs-server',
   exports_path: '/etc/exports',
-  exports:      [],
+  exports: [],
 }

--- a/infrastructure/cinc/cookbooks/nfs/kitchen.yml
+++ b/infrastructure/cinc/cookbooks/nfs/kitchen.yml
@@ -1,0 +1,63 @@
+---
+# -------------------------------------------------------------------------------
+# Test-Kitchen config for nfs.
+#
+# Two suites:
+#   - server: installs nfs-kernel-server + renders /etc/exports with a sample
+#     export. exportfs is run by the resource; export becomes reachable via
+#     localhost:2049 in the guest.
+#   - client: installs nfs-common + creates a mount point dir. Actually
+#     mounting from an external server isn't viable in a libvirt guest with
+#     no NFS peer reachable, so the client suite sets mounts=[] and only
+#     proves package install + the mount-point dir resource shape.
+#
+# README.md explains the live-mount caveat.
+# -------------------------------------------------------------------------------
+
+driver:
+  name: vagrant
+  provider: libvirt
+  customize:
+    memory: 512
+    cpus: 1
+
+provisioner:
+  name: chef_zero
+  product_name: cinc
+  product_version: latest
+  install_strategy: once
+  multiple_converge: 2
+  enforce_idempotency: true
+  chef_license: accept
+  log_level: warn
+
+verifier:
+  name: inspec
+  format: doc
+
+platforms:
+  - name: debian-12
+    driver:
+      box: generic/debian12
+
+suites:
+  - name: server
+    run_list:
+      - recipe[nfs::server]
+    attributes:
+      nfs:
+        server:
+          exports:
+            - path: /srv/nfs/test
+              clients: 127.0.0.0/8
+              options: rw,sync,no_subtree_check,no_root_squash
+    verifier:
+      inspec_tests:
+        - test/integration/server
+
+  - name: client
+    run_list:
+      - recipe[nfs::client]
+    verifier:
+      inspec_tests:
+        - test/integration/client

--- a/infrastructure/cinc/cookbooks/nfs/spec/recipes/client_spec.rb
+++ b/infrastructure/cinc/cookbooks/nfs/spec/recipes/client_spec.rb
@@ -1,0 +1,86 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+# -------------------------------------------------------------------------------
+# client recipe spec -- steps into nfs_mount to cover the directory + mount
+# resources it declares.
+# -------------------------------------------------------------------------------
+
+RSpec.describe 'nfs::client' do
+  cached(:chef_run) do
+    ChefSpec::SoloRunner.new(step_into: %w(nfs_mount)).converge(described_recipe)
+  end
+
+  it 'installs nfs-common' do
+    expect(chef_run).to install_apt_package('nfs-common')
+  end
+
+  it 'declares no nfs_mount resources when mounts is empty (the default)' do
+    expect(chef_run.find_resources(:nfs_mount)).to be_empty
+  end
+
+  context 'with a shared mount declared via attributes' do
+    cached(:with_mount_run) do
+      allow(::File).to receive(:directory?).and_call_original
+      allow(::File).to receive(:directory?).with('/mnt/gdrive').and_return(false)
+      ChefSpec::SoloRunner.new(step_into: %w(nfs_mount)) do |node|
+        node.normal['nfs']['client']['mounts'] = [
+          { 'mount_point' => '/mnt/gdrive', 'device' => 'mccoy:/mnt/gdrive' },
+        ]
+      end.converge(described_recipe)
+    end
+
+    it 'declares the nfs_mount keyed by mount_point' do
+      expect(with_mount_run).to create_nfs_mount('/mnt/gdrive')
+        .with(device: 'mccoy:/mnt/gdrive')
+    end
+
+    it 'creates the mount-point directory root:root 0755 (recursive)' do
+      expect(with_mount_run).to create_directory('/mnt/gdrive')
+        .with(owner: 'root', group: 'root', mode: '0755', recursive: true)
+    end
+
+    it 'mounts and enables the export in fstab' do
+      # --- chef splits the comma-joined options string into an array at parse time ---
+      expect(with_mount_run).to mount_mount('/mnt/gdrive')
+        .with(device: 'mccoy:/mnt/gdrive', fstype: 'nfs', options: %w(defaults _netdev))
+      expect(with_mount_run).to enable_mount('/mnt/gdrive')
+    end
+  end
+
+  context 'with both mounts + extra_mounts populated' do
+    cached(:two_mounts_run) do
+      allow(::File).to receive(:directory?).and_call_original
+      allow(::File).to receive(:directory?).with('/mnt/shared').and_return(false)
+      allow(::File).to receive(:directory?).with('/mnt/node-only').and_return(false)
+      ChefSpec::SoloRunner.new(step_into: %w(nfs_mount)) do |node|
+        node.normal['nfs']['client']['mounts'] = [
+          { 'mount_point' => '/mnt/shared', 'device' => 'mccoy:/mnt/shared' },
+        ]
+        node.normal['nfs']['client']['extra_mounts'] = [
+          { 'mount_point' => '/mnt/node-only', 'device' => 'mccoy:/mnt/node-only',
+            'fstype' => 'nfs4', 'options' => 'rw,vers=4' },
+        ]
+      end.converge(described_recipe)
+    end
+
+    it 'materializes both lists' do
+      expect(two_mounts_run).to create_nfs_mount('/mnt/shared')
+      expect(two_mounts_run).to create_nfs_mount('/mnt/node-only')
+        .with(fstype: 'nfs4', options: 'rw,vers=4')
+    end
+
+    it 'creates the mount-point directories for both' do
+      expect(two_mounts_run).to create_directory('/mnt/shared')
+      expect(two_mounts_run).to create_directory('/mnt/node-only')
+    end
+
+    it 'mounts both with their respective fstype/options' do
+      expect(two_mounts_run).to mount_mount('/mnt/shared')
+        .with(fstype: 'nfs')
+      expect(two_mounts_run).to mount_mount('/mnt/node-only')
+        .with(fstype: 'nfs4', options: %w(rw vers=4))
+    end
+  end
+end

--- a/infrastructure/cinc/cookbooks/nfs/spec/recipes/default_spec.rb
+++ b/infrastructure/cinc/cookbooks/nfs/spec/recipes/default_spec.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+# -------------------------------------------------------------------------------
+# default recipe spec -- intentionally empty; opt in via role.
+# -------------------------------------------------------------------------------
+
+RSpec.describe 'nfs::default' do
+  cached(:chef_run) { ChefSpec::SoloRunner.new.converge(described_recipe) }
+
+  it 'converges without declaring any resources' do
+    expect(chef_run.resource_collection.map(&:to_s)).to be_empty
+  end
+end

--- a/infrastructure/cinc/cookbooks/nfs/spec/recipes/server_spec.rb
+++ b/infrastructure/cinc/cookbooks/nfs/spec/recipes/server_spec.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+# -------------------------------------------------------------------------------
+# server recipe spec -- steps into nfs_server. Empty exports = no-op; with
+# exports, renders /etc/exports + notifies exportfs -ra.
+# -------------------------------------------------------------------------------
+
+RSpec.describe 'nfs::server' do
+  cached(:default_run) do
+    ChefSpec::SoloRunner.new(step_into: %w(nfs_server)).converge(described_recipe)
+  end
+
+  it 'declares the nfs_server resource' do
+    expect(default_run).to configure_nfs_server('nfs-server')
+      .with(
+        package: 'nfs-kernel-server',
+        exports_path: '/etc/exports',
+        service_name: 'nfs-server'
+      )
+  end
+
+  it 'is a no-op when exports is empty (the default)' do
+    # --- early return skips package/file/service/execute resources entirely ---
+    expect(default_run.find_resources(:apt_package)).to be_empty
+    expect(default_run.find_resources(:file).map(&:name)).not_to include('/etc/exports')
+    expect(default_run.find_resources(:service)).to be_empty
+  end
+
+  context 'with exports populated via attributes' do
+    cached(:exports_run) do
+      ChefSpec::SoloRunner.new(step_into: %w(nfs_server)) do |node|
+        node.normal['nfs']['server']['exports'] = [
+          { 'path' => '/srv/nfs/test', 'clients' => '127.0.0.0/8',
+            'options' => 'rw,sync,no_subtree_check,no_root_squash' },
+        ]
+      end.converge(described_recipe)
+    end
+
+    it 'installs nfs-kernel-server' do
+      expect(exports_run).to install_apt_package('nfs-kernel-server')
+    end
+
+    it 'renders /etc/exports root:root 0644 with the managed-block header + entry' do
+      expect(exports_run).to create_file('/etc/exports')
+        .with(owner: 'root', group: 'root', mode: '0644')
+      rendered = exports_run.file('/etc/exports').content
+      expect(rendered).to match(/managed by chef/)
+      expect(rendered).to include('/srv/nfs/test 127.0.0.0/8(rw,sync,no_subtree_check,no_root_squash)')
+    end
+
+    it 'notifies exportfs -ra (delayed) when /etc/exports changes' do
+      expect(exports_run.file('/etc/exports'))
+        .to notify('execute[exportfs -ra]').to(:run).delayed
+    end
+
+    it 'declares the exportfs execute as :nothing (only fires on notify)' do
+      expect(exports_run.execute('exportfs -ra')).to do_nothing
+    end
+
+    it 'enables + starts nfs-server' do
+      expect(exports_run).to enable_service('nfs-server')
+      expect(exports_run).to start_service('nfs-server')
+    end
+  end
+end

--- a/infrastructure/cinc/cookbooks/nfs/spec/spec_helper.rb
+++ b/infrastructure/cinc/cookbooks/nfs/spec/spec_helper.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+# -------------------------------------------------------------------------------
+# Cookbook:: nfs
+# Spec helper.
+# -------------------------------------------------------------------------------
+
+require 'chefspec'
+
+Dir[File.expand_path('support/**/*.rb', __dir__)].each { |f| require f }
+
+ChefSpec::Coverage.start! { add_filter 'munchbox_lib' }
+
+RSpec.configure do |config|
+  config.cookbook_path = [File.expand_path('../../', __dir__)]
+  config.platform        = 'debian'
+  config.version         = '12'
+  config.log_level       = :error
+  config.disable_monkey_patching!
+  config.order = :random
+  Kernel.srand(config.seed)
+end

--- a/infrastructure/cinc/cookbooks/nfs/spec/support/matchers.rb
+++ b/infrastructure/cinc/cookbooks/nfs/spec/support/matchers.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+# -------------------------------------------------------------------------------
+# Custom rspec/chefspec matchers.
+# -------------------------------------------------------------------------------
+
+RSpec::Matchers.define :do_nothing do
+  match do |resource|
+    next false unless resource
+
+    ChefSpec::Coverage.cover!(resource)
+    actions = Array(resource.action)
+    actions.include?(:nothing)
+  end
+
+  failure_message do |resource|
+    if resource.nil?
+      'expected a chef resource but got nil'
+    else
+      "expected #{resource} to have action :nothing, got #{Array(resource.action).inspect}"
+    end
+  end
+end

--- a/infrastructure/cinc/cookbooks/nfs/test/integration/client/controls/client.rb
+++ b/infrastructure/cinc/cookbooks/nfs/test/integration/client/controls/client.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+# -------------------------------------------------------------------------------
+# nfs::client integration controls (package install only; no live mounts).
+# -------------------------------------------------------------------------------
+
+control 'nfs-common-installed' do
+  impact 1.0
+  title 'nfs-common package is installed'
+
+  describe package('nfs-common') do
+    it { should be_installed }
+  end
+end

--- a/infrastructure/cinc/cookbooks/nfs/test/integration/client/inspec.yml
+++ b/infrastructure/cinc/cookbooks/nfs/test/integration/client/inspec.yml
@@ -1,0 +1,10 @@
+---
+name: nfs-client
+title: nfs client integration controls
+maintainer: Alex Freidah
+copyright: Alex Freidah
+license: MIT
+summary: Validates a converged nfs::client -- nfs-common installed; actual mounts not exercised (no reachable peer in kitchen).
+version: 0.1.0
+supports:
+  - platform: debian

--- a/infrastructure/cinc/cookbooks/nfs/test/integration/server/controls/server.rb
+++ b/infrastructure/cinc/cookbooks/nfs/test/integration/server/controls/server.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+# -------------------------------------------------------------------------------
+# nfs::server integration controls.
+# -------------------------------------------------------------------------------
+
+control 'nfs-kernel-server-installed' do
+  impact 1.0
+  title 'nfs-kernel-server package is installed'
+
+  describe package('nfs-kernel-server') do
+    it { should be_installed }
+  end
+end
+
+control 'exports-rendered' do
+  impact 1.0
+  title '/etc/exports has the managed-block header + sample export'
+
+  describe file('/etc/exports') do
+    it { should exist }
+    its('owner') { should eq 'root' }
+    its('group') { should eq 'root' }
+    its('mode')  { should cmp '0644' }
+    its('content') { should match(/managed by chef/) }
+    its('content') { should include('/srv/nfs/test 127.0.0.0/8(rw,sync,no_subtree_check,no_root_squash)') }
+  end
+end
+
+control 'nfs-server-service' do
+  impact 1.0
+  title 'nfs-server systemd unit is enabled + running'
+
+  describe service('nfs-server') do
+    it { should be_installed }
+    it { should be_enabled }
+    it { should be_running }
+  end
+end

--- a/infrastructure/cinc/cookbooks/nfs/test/integration/server/inspec.yml
+++ b/infrastructure/cinc/cookbooks/nfs/test/integration/server/inspec.yml
@@ -1,0 +1,10 @@
+---
+name: nfs-server
+title: nfs server integration controls
+maintainer: Alex Freidah
+copyright: Alex Freidah
+license: MIT
+summary: Validates a converged nfs::server -- nfs-kernel-server installed, exports rendered, service running.
+version: 0.1.0
+supports:
+  - platform: debian

--- a/infrastructure/cinc/cookbooks/nomad/attributes/default.rb
+++ b/infrastructure/cinc/cookbooks/nomad/attributes/default.rb
@@ -144,43 +144,43 @@ default[cookbook]['config'] = {
 
 default[cookbook]['auto_restart_webhook'] = {
   # --- Identity / service ---
-  service_name:        'nomad-auto-restart-webhook',
+  service_name: 'nomad-auto-restart-webhook',
   service_description: 'AlertManager Webhook for Nomad Job Auto-Restart',
-  user:                'root',
-  group:               'root',
+  user: 'root',
+  group: 'root',
 
   # --- Network / receiver behavior ---
-  port:                9095,
-  bind_address:        '0.0.0.0',
-  cooldown_seconds:    300,
-  cooldown_dir:        '/tmp/nomad-restart-cooldown',
-  log_file:            '/var/log/nomad-auto-restart.log',
+  port: 9095,
+  bind_address: '0.0.0.0',
+  cooldown_seconds: 300,
+  cooldown_dir: '/tmp/nomad-restart-cooldown',
+  log_file: '/var/log/nomad-auto-restart.log',
 
   # --- On-disk paths ---
-  python_bin:          '/usr/bin/python3',
-  script_path:         '/usr/local/bin/nomad-auto-restart-webhook.py',
+  python_bin: '/usr/bin/python3',
+  script_path: '/usr/local/bin/nomad-auto-restart-webhook.py',
 
   # --- Systemd dependencies ---
-  after_units:         %w(network.target nomad.service),
-  wants_units:         %w(nomad.service),
-  restart_policy:      'always',
-  restart_sec:         5,
+  after_units: %w(network.target nomad.service),
+  wants_units: %w(nomad.service),
+  restart_policy: 'always',
+  restart_sec: 5,
 
   # --- Nomad client env (mTLS to the local agent) ---
-  nomad_addr:          'https://127.0.0.1:4646',
-  nomad_cacert:        '/etc/nomad.d/tls/ca.crt',
-  nomad_client_cert:   '/etc/nomad.d/tls/nomad.crt',
-  nomad_client_key:    '/etc/nomad.d/tls/nomad.key',
+  nomad_addr: 'https://127.0.0.1:4646',
+  nomad_cacert: '/etc/nomad.d/tls/ca.crt',
+  nomad_client_cert: '/etc/nomad.d/tls/nomad.crt',
+  nomad_client_key: '/etc/nomad.d/tls/nomad.key',
 
   # --- Consul service registration ---
-  consul_service_file:     '/etc/consul.d/nomad-auto-restart-webhook.json',
-  consul_service_name:     'nomad-auto-restart-webhook',
-  consul_service_tags:     %w(alertmanager webhook infrastructure),
-  consul_check_path:       '/',
-  consul_check_interval:   '30s',
-  consul_check_timeout:    '5s',
-  consul_user:             'consul',
-  consul_group:            'consul',
+  consul_service_file: '/etc/consul.d/nomad-auto-restart-webhook.json',
+  consul_service_name: 'nomad-auto-restart-webhook',
+  consul_service_tags: %w(alertmanager webhook infrastructure),
+  consul_check_path: '/',
+  consul_check_interval: '30s',
+  consul_check_timeout: '5s',
+  consul_user: 'consul',
+  consul_group: 'consul',
 
   # --- Bash predecessor (replaced by python); swept on every converge. ---
   stale_paths: [

--- a/infrastructure/cinc/cookbooks/nomad/resources/nomad_auto_restart_webhook.rb
+++ b/infrastructure/cinc/cookbooks/nomad/resources/nomad_auto_restart_webhook.rb
@@ -132,11 +132,11 @@ action :configure do
     mode   '0640'
     variables(
       service_name: new_resource.consul_service_name,
-      tags:         new_resource.consul_service_tags,
-      port:         new_resource.port,
-      check_path:   new_resource.consul_check_path,
-      interval:     new_resource.consul_check_interval,
-      timeout:      new_resource.consul_check_timeout
+      tags: new_resource.consul_service_tags,
+      port: new_resource.port,
+      check_path: new_resource.consul_check_path,
+      interval: new_resource.consul_check_interval,
+      timeout: new_resource.consul_check_timeout
     )
     notifies :reload, 'service[consul]', :delayed
   end

--- a/infrastructure/cinc/cookbooks/nomad/resources/nomad_configure.rb
+++ b/infrastructure/cinc/cookbooks/nomad/resources/nomad_configure.rb
@@ -37,7 +37,7 @@ property :client_enabled,             [true, false], default: true
 property :servers,                    Array, default: []
 property :node_pool,                  String, default: 'default'
 property :node_class,                 [String, nil]
-property :client_meta,                Hash,   default: {}
+property :client_meta,                Hash, default: {}
 property :network_interface,          [String, nil]
 property :gc_disk_usage_threshold,    Integer, default: 80
 property :gc_inode_usage_threshold,   Integer, default: 70

--- a/infrastructure/cinc/cookbooks/nomad/spec/recipes/auto_restart_webhook_spec.rb
+++ b/infrastructure/cinc/cookbooks/nomad/spec/recipes/auto_restart_webhook_spec.rb
@@ -1,0 +1,98 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+# -------------------------------------------------------------------------------
+# auto_restart_webhook recipe spec -- steps into nomad_auto_restart_webhook so
+# the file/template/systemd_unit/service resources it declares are covered.
+# vault_fetch is stubbed globally in spec_helper.
+# -------------------------------------------------------------------------------
+
+RSpec.describe 'nomad::auto_restart_webhook' do
+  cached(:chef_run) do
+    ChefSpec::SoloRunner.new(step_into: %w(nomad_auto_restart_webhook)).converge(described_recipe)
+  end
+
+  it 'declares the wrapping resource' do
+    expect(chef_run).to configure_nomad_auto_restart_webhook('baseline')
+      .with(
+        service_name: 'nomad-auto-restart-webhook',
+        port: 9095,
+        user: 'root',
+        group: 'root'
+      )
+  end
+
+  it 'renders the webhook python script with the configured port + paths' do
+    expect(chef_run).to create_template('/usr/local/bin/nomad-auto-restart-webhook.py')
+      .with(owner: 'root', group: 'root', mode: '0755')
+    tpl = chef_run.template('/usr/local/bin/nomad-auto-restart-webhook.py')
+    expect(tpl.variables[:port]).to eq(9095)
+    expect(tpl.variables[:bind_address]).to eq('0.0.0.0')
+    expect(tpl.variables[:cooldown_seconds]).to eq(300)
+    expect(tpl.variables[:cooldown_dir]).to eq('/tmp/nomad-restart-cooldown')
+    expect(tpl.variables[:log_file]).to eq('/var/log/nomad-auto-restart.log')
+  end
+
+  it 'creates + enables + starts the systemd unit with NOMAD_TOKEN from vault' do
+    expect(chef_run).to create_systemd_unit('nomad-auto-restart-webhook.service')
+    expect(chef_run).to enable_systemd_unit('nomad-auto-restart-webhook.service')
+    expect(chef_run).to start_systemd_unit('nomad-auto-restart-webhook.service')
+    unit = chef_run.systemd_unit('nomad-auto-restart-webhook.service')
+    expect(unit.content).to include('Environment=NOMAD_TOKEN=fake-vault-value')
+    expect(unit.content).to include('ExecStart=/usr/bin/python3 /usr/local/bin/nomad-auto-restart-webhook.py')
+  end
+
+  it 'renders the consul-service JSON consul:consul 0640 with the same port the script binds' do
+    expect(chef_run).to create_template('/etc/consul.d/nomad-auto-restart-webhook.json')
+      .with(owner: 'consul', group: 'consul', mode: '0640')
+    tpl = chef_run.template('/etc/consul.d/nomad-auto-restart-webhook.json')
+    expect(tpl.variables[:service_name]).to eq('nomad-auto-restart-webhook')
+    expect(tpl.variables[:port]).to eq(9095)
+    expect(tpl.variables[:check_path]).to eq('/')
+  end
+
+  it 'notifies consul to reload (delayed) when the consul-service template changes' do
+    expect(chef_run.template('/etc/consul.d/nomad-auto-restart-webhook.json'))
+      .to notify('service[consul]').to(:reload).delayed
+  end
+
+  it 'enables + starts the webhook service' do
+    expect(chef_run).to enable_service('nomad-auto-restart-webhook')
+    expect(chef_run).to start_service('nomad-auto-restart-webhook')
+  end
+
+  it 'declares consul service with :nothing so notify hooks resolve' do
+    expect(chef_run.service('consul')).to do_nothing
+  end
+
+  it 'sweeps the default ansible-era webhook .sh leftover' do
+    expect(chef_run).to delete_file('/usr/local/bin/nomad-auto-restart-webhook.sh')
+  end
+
+  context 'when nomad_token is empty' do
+    before do
+      MunchboxLibVaultFetch.module_eval do
+        define_method(:vault_fetch) { |_path, _field| '' }
+      end
+    end
+
+    it 'raises rather than rendering an unauthenticated systemd unit' do
+      expect do
+        ChefSpec::SoloRunner.new(step_into: %w(nomad_auto_restart_webhook)).converge(described_recipe)
+      end.to raise_error(/nomad_token cannot be empty/)
+    end
+  end
+
+  context 'with stale_paths configured' do
+    cached(:sweep_run) do
+      ChefSpec::SoloRunner.new(step_into: %w(nomad_auto_restart_webhook)) do |node|
+        node.normal['nomad']['auto_restart_webhook']['stale_paths'] = ['/usr/local/bin/nomad-auto-restart.sh']
+      end.converge(described_recipe)
+    end
+
+    it 'sweeps each stale path' do
+      expect(sweep_run).to delete_file('/usr/local/bin/nomad-auto-restart.sh')
+    end
+  end
+end

--- a/infrastructure/cinc/cookbooks/nomad/spec/recipes/configure_spec.rb
+++ b/infrastructure/cinc/cookbooks/nomad/spec/recipes/configure_spec.rb
@@ -43,6 +43,22 @@ RSpec.describe 'nomad::configure' do
         .with(owner: 'root', group: 'root', mode: '0640')
     end
 
+    it 'sweeps the default ansible-era stale_paths' do
+      %w(
+        /etc/nomad.d/nomad.hcl.bak
+        /etc/nomad.d/nomad.hcl.broken
+        /etc/nomad.d/consul_token.env
+        /etc/nomad.d/010-client-tags.hcl
+        /etc/systemd/system/nomad.service.d/10-consul-token.conf
+      ).each do |p|
+        expect(chef_run).to delete_file(p)
+      end
+    end
+
+    it 'declares the daemon-reload execute (notified by stale_paths sweep)' do
+      expect(chef_run.execute('systemctl daemon-reload (nomad stale-paths sweep)')).to do_nothing
+    end
+
     # --- Per-node attrs propagate ---
     it 'passes node_name, bind_addr, advertise_ip, server_enabled=false through to the template' do
       template = chef_run.template('/etc/nomad.d/nomad.hcl')

--- a/infrastructure/cinc/cookbooks/nomad/spec/recipes/install_spec.rb
+++ b/infrastructure/cinc/cookbooks/nomad/spec/recipes/install_spec.rb
@@ -46,4 +46,18 @@ RSpec.describe 'nomad::install' do
   it 'installs unzip' do
     expect(chef_run).to install_package('unzip')
   end
+
+  it 'fetches the nomad release archive' do
+    expect(chef_run).to create_remote_file(%r{/tmp/nomad_.+_linux_.+\.zip})
+  end
+
+  it 'declares the nomad service (action :nothing; notified by install)' do
+    expect(chef_run.service('nomad')).to do_nothing
+  end
+
+  it 'installs the nomad binary via the install execute resource' do
+    matched = chef_run.find_resources(:execute).find { |r| r.name.start_with?('install nomad ') }
+    expect(matched).not_to be_nil
+    ChefSpec::Coverage.cover!(matched)
+  end
 end

--- a/infrastructure/cinc/cookbooks/nomad/spec/spec_helper.rb
+++ b/infrastructure/cinc/cookbooks/nomad/spec/spec_helper.rb
@@ -7,9 +7,22 @@
 
 require 'chefspec'
 
+# --- Load vault_fetch lib so MunchboxLibVaultFetch exists for the stub below ---
+require File.expand_path('../../munchbox_lib/libraries/vault_fetch.rb', __dir__)
+
 Dir[File.expand_path('support/**/*.rb', __dir__)].each { |f| require f }
 
 ChefSpec::Coverage.start! { add_filter 'munchbox_lib' }
+
+# --- Stub vault_fetch globally; module monkey-patch is the only reliable way
+#     (allow_any_instance_of misses lazy-block calls on resource properties).
+RSpec.configure do |c|
+  c.before(:each) do
+    MunchboxLibVaultFetch.module_eval do
+      define_method(:vault_fetch) { |_path, _field| 'fake-vault-value' }
+    end
+  end
+end
 
 RSpec.configure do |config|
   config.cookbook_path = [

--- a/infrastructure/cinc/cookbooks/nvidia/.gitignore
+++ b/infrastructure/cinc/cookbooks/nvidia/.gitignore
@@ -1,0 +1,5 @@
+.kitchen/
+kitchen.local.yml
+.ruby-lsp/
+vendor/bundle/
+Berksfile.lock

--- a/infrastructure/cinc/cookbooks/nvidia/.rubocop.yml
+++ b/infrastructure/cinc/cookbooks/nvidia/.rubocop.yml
@@ -1,0 +1,33 @@
+# -------------------------------------------------------------------------------
+# Cookstyle (rubocop) config for nvidia.
+# -------------------------------------------------------------------------------
+
+require:
+  - cookstyle
+
+inherit_gem:
+  cookstyle: config/cookstyle.yml
+
+AllCops:
+  NewCops: enable
+  TargetRubyVersion: 3.1
+  Exclude:
+    - 'Berksfile.lock'
+    - 'Gemfile.lock'
+    - 'tmp/**/*'
+    - 'vendor/**/*'
+
+Layout/LineLength:
+  Max: 120
+
+Metrics/BlockLength:
+  Exclude:
+    - 'spec/**/*'
+    - 'test/**/*'
+
+# --- nvidia_install drops the debian-nonfree sources list as a plain file
+#     (notified to a deferred execute "apt-get update"). Can't use apt_update
+#     here because the apt_repository abstraction would force a signed-by=
+#     pointing at our empty keyring, breaking bookworm signature verification.
+Chef/Modernize/ExecuteAptUpdate:
+  Enabled: false

--- a/infrastructure/cinc/cookbooks/nvidia/Berksfile
+++ b/infrastructure/cinc/cookbooks/nvidia/Berksfile
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+source chef_repo: '../..'
+
+metadata

--- a/infrastructure/cinc/cookbooks/nvidia/Makefile
+++ b/infrastructure/cinc/cookbooks/nvidia/Makefile
@@ -1,0 +1,45 @@
+# -------------------------------------------------------------------------------
+# Cookbook:: nvidia
+# Makefile -- delegates to cinc-workstation tools.
+# -------------------------------------------------------------------------------
+
+CHEF      := /usr/local/bin/chef
+COOKSTYLE := /usr/local/bin/cookstyle
+KITCHEN   := /usr/local/bin/kitchen
+
+.PHONY: help tools test lint kitchen create converge verify login destroy
+
+help:
+	@echo "make tools     - install cinc-workstation + libvirt/vagrant stack (one-time host setup)"
+	@echo "make lint      - cookstyle (rubocop with chef cops)"
+	@echo "make test      - chefspec/rspec unit tests"
+	@echo ""
+	@echo "Kitchen is intentionally a no-op for nvidia (no GPU in kitchen VMs);"
+	@echo "see README.md for the rationale."
+
+tools:
+	../../scripts/kitchen/debian.sh
+
+lint:
+	$(COOKSTYLE) .
+
+test:
+	$(CHEF) exec rspec spec/
+
+kitchen:
+	$(KITCHEN) test
+
+create:
+	$(KITCHEN) create
+
+converge:
+	$(KITCHEN) converge
+
+verify:
+	$(KITCHEN) verify
+
+login:
+	$(KITCHEN) login
+
+destroy:
+	$(KITCHEN) destroy

--- a/infrastructure/cinc/cookbooks/nvidia/README.md
+++ b/infrastructure/cinc/cookbooks/nvidia/README.md
@@ -1,0 +1,26 @@
+# nvidia
+
+Installs the Debian-shipped NVIDIA proprietary driver and `nvidia-container-toolkit`. Required for the docker `nvidia` runtime (declared elsewhere via `docker.daemon.extra` on the GPU host's role).
+
+Currently only `nomad-client-04` runs this (the media-stack node with GPU passthrough).
+
+## Recipes
+
+| Recipe | Purpose |
+|---|---|
+| `default` | Empty; opt in via role. |
+| `install` | Debian non-free repo + nvidia toolkit repo + driver + toolkit packages. |
+
+## Testing
+
+```
+make lint
+make test
+```
+
+### Why no `make kitchen`
+
+- The proprietary `nvidia-driver` requires real NVIDIA hardware; the libvirt guest doesn't have any.
+- DKMS-style driver builds need matching kernel headers compiled against the running kernel; the kitchen guest's kernel is irrelevant.
+
+Verify changes live on the GPU host: bump `version` in the role, push, `cinc-client`, then `nvidia-smi` + `docker info | grep -i runtime`.

--- a/infrastructure/cinc/cookbooks/nvidia/kitchen.yml
+++ b/infrastructure/cinc/cookbooks/nvidia/kitchen.yml
@@ -1,0 +1,31 @@
+---
+# -------------------------------------------------------------------------------
+# Test-Kitchen config for nvidia.
+#
+# No suites: kitchen is intentionally skipped because (a) the proprietary
+# nvidia-driver requires real NVIDIA hardware on the test VM and (b) DKMS
+# wants matching kernel headers compiled against a kernel that the libvirt
+# guest doesn't run. Chefspec covers the resource shape; live verification
+# happens on the GPU host (nomad-client-04) via cinc-client + nvidia-smi.
+#
+# See README.md.
+# -------------------------------------------------------------------------------
+
+driver:
+  name: vagrant
+  provider: libvirt
+
+provisioner:
+  name: chef_zero
+  product_name: cinc
+  chef_license: accept
+
+verifier:
+  name: inspec
+
+platforms:
+  - name: debian-12
+    driver:
+      box: generic/debian12
+
+suites: []

--- a/infrastructure/cinc/cookbooks/nvidia/spec/recipes/default_spec.rb
+++ b/infrastructure/cinc/cookbooks/nvidia/spec/recipes/default_spec.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+# -------------------------------------------------------------------------------
+# default recipe spec -- intentionally empty; opt in via role.
+# -------------------------------------------------------------------------------
+
+RSpec.describe 'nvidia::default' do
+  cached(:chef_run) { ChefSpec::SoloRunner.new.converge(described_recipe) }
+
+  it 'converges without declaring any resources' do
+    expect(chef_run.resource_collection.map(&:to_s)).to be_empty
+  end
+end

--- a/infrastructure/cinc/cookbooks/nvidia/spec/recipes/install_spec.rb
+++ b/infrastructure/cinc/cookbooks/nvidia/spec/recipes/install_spec.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+# -------------------------------------------------------------------------------
+# install recipe spec -- steps into nvidia_install to cover the underlying
+# file/apt_repository/apt_package resources.
+# -------------------------------------------------------------------------------
+
+RSpec.describe 'nvidia::install' do
+  cached(:chef_run) do
+    ChefSpec::SoloRunner.new(step_into: %w(nvidia_install)).converge(described_recipe)
+  end
+
+  it 'declares the nvidia_install resource' do
+    expect(chef_run).to install_nvidia_install('baseline')
+      .with(
+        debian_nonfree_components: %w(main contrib non-free non-free-firmware),
+        container_toolkit_repo_uri: 'https://nvidia.github.io/libnvidia-container/stable/deb/$(ARCH)',
+        container_toolkit_key_url: 'https://nvidia.github.io/libnvidia-container/gpgkey',
+        install_kernel_headers: true,
+        packages: %w(nvidia-driver nvidia-container-toolkit)
+      )
+  end
+
+  it 'writes the debian non-free sources.list with the running codename' do
+    expect(chef_run).to create_file('/etc/apt/sources.list.d/debian-nonfree.list')
+      .with(owner: 'root', group: 'root', mode: '0644')
+    rendered = chef_run.file('/etc/apt/sources.list.d/debian-nonfree.list').content
+    expect(rendered).to match(%r{^deb http://deb\.debian\.org/debian \w+ main contrib non-free non-free-firmware$})
+  end
+
+  it 'declares the deferred apt-get update execute (action :nothing)' do
+    expect(chef_run.execute('apt-get update (debian-nonfree)')).to do_nothing
+  end
+
+  it 'notifies the apt-get update execute immediately when the sources file changes' do
+    expect(chef_run.file('/etc/apt/sources.list.d/debian-nonfree.list'))
+      .to notify('execute[apt-get update (debian-nonfree)]').to(:run).immediately
+  end
+
+  it 'adds the nvidia-container-toolkit apt repository' do
+    expect(chef_run).to add_apt_repository('nvidia-container-toolkit')
+      .with(
+        uri: 'https://nvidia.github.io/libnvidia-container/stable/deb/$(ARCH)',
+        distribution: '/',
+        key: ['https://nvidia.github.io/libnvidia-container/gpgkey']
+      )
+  end
+
+  it 'installs the linux-headers package matching the running kernel' do
+    expect(chef_run).to install_apt_package("linux-headers-#{chef_run.node['kernel']['release']}")
+  end
+
+  it 'installs the nvidia driver + container toolkit packages' do
+    expect(chef_run).to install_apt_package(%w(nvidia-driver nvidia-container-toolkit))
+  end
+
+  it 'waits for the apt lock around both the repo + package steps' do
+    expect(chef_run).to wait_munchbox_base_apt_lock_wait('nvidia_install_repos')
+    expect(chef_run).to wait_munchbox_base_apt_lock_wait('nvidia_install_packages')
+  end
+
+  context 'with install_kernel_headers disabled' do
+    cached(:no_headers_run) do
+      ChefSpec::SoloRunner.new(step_into: %w(nvidia_install)) do |node|
+        node.normal['nvidia']['install']['install_kernel_headers'] = false
+      end.converge(described_recipe)
+    end
+
+    it 'omits the linux-headers apt_package' do
+      headers = "linux-headers-#{no_headers_run.node['kernel']['release']}"
+      expect(no_headers_run.find_resources(:apt_package).map(&:name)).not_to include(headers)
+    end
+  end
+end

--- a/infrastructure/cinc/cookbooks/nvidia/spec/spec_helper.rb
+++ b/infrastructure/cinc/cookbooks/nvidia/spec/spec_helper.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+# -------------------------------------------------------------------------------
+# Cookbook:: nvidia
+# Spec helper.
+# -------------------------------------------------------------------------------
+
+require 'chefspec'
+
+Dir[File.expand_path('support/**/*.rb', __dir__)].each { |f| require f }
+
+ChefSpec::Coverage.start! do
+  add_filter 'munchbox_lib'
+  add_filter 'munchbox_base'
+end
+
+RSpec.configure do |config|
+  config.cookbook_path = [File.expand_path('../../', __dir__)]
+  config.platform        = 'debian'
+  config.version         = '12'
+  config.log_level       = :error
+  config.disable_monkey_patching!
+  config.order = :random
+  Kernel.srand(config.seed)
+end

--- a/infrastructure/cinc/cookbooks/nvidia/spec/support/matchers.rb
+++ b/infrastructure/cinc/cookbooks/nvidia/spec/support/matchers.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+# -------------------------------------------------------------------------------
+# Custom rspec/chefspec matchers.
+# -------------------------------------------------------------------------------
+
+RSpec::Matchers.define :do_nothing do
+  match do |resource|
+    next false unless resource
+
+    ChefSpec::Coverage.cover!(resource)
+    actions = Array(resource.action)
+    actions.include?(:nothing)
+  end
+
+  failure_message do |resource|
+    if resource.nil?
+      'expected a chef resource but got nil'
+    else
+      "expected #{resource} to have action :nothing, got #{Array(resource.action).inspect}"
+    end
+  end
+end

--- a/infrastructure/cinc/cookbooks/oracle/README.md
+++ b/infrastructure/cinc/cookbooks/oracle/README.md
@@ -1,0 +1,27 @@
+# oracle
+
+Oracle Cloud node tweaks: the watchdog daemon (consul session heartbeat for the oracle node's health signal) and the persistent OCI block-volume mount for MinIO.
+
+## Recipes
+
+| Recipe | Purpose |
+|---|---|
+| `default` | Empty; opt in via role. |
+| `watchdog` | `oracle-watchdog` package + config.yaml + systemd Environment override (CONSUL_HTTP_ADDR + ACL token from Vault) + consul service registration. Work lives in `oracle_watchdog`. |
+| `minio_mount` | UUID-based fstab entry for the OCI block volume labeled `minio-data` (sweeps the legacy `/dev/sdb` entry). Work lives in `oracle_minio_mount`. |
+
+## Testing
+
+```
+make lint
+make test
+```
+
+### Why no `make kitchen` suite
+
+Both recipes need live infrastructure to mean anything:
+
+- `watchdog` reads the consul ACL token from Vault and notifies a running consul daemon to reload its service catalog.
+- `minio_mount` expects an OCI block volume labeled `minio-data` to be attached to the guest. libvirt can't provide that.
+
+Specs cover the resource shape exhaustively (step_into both `oracle_watchdog` and `oracle_minio_mount`). Real verification: `cinc-client -W` dry-run against a target oracle node.

--- a/infrastructure/cinc/cookbooks/oracle/kitchen.yml
+++ b/infrastructure/cinc/cookbooks/oracle/kitchen.yml
@@ -1,0 +1,42 @@
+---
+# -------------------------------------------------------------------------------
+# Test-Kitchen config for oracle.
+#
+# Both recipes need live infrastructure to actually exercise end-to-end:
+#   - watchdog needs Vault for the consul ACL token + the consul daemon to
+#     reload on service-file change.
+#   - minio_mount needs an OCI block volume labeled `minio-data` attached
+#     to the guest -- not viable in libvirt.
+#
+# Kitchen here only proves the suites load + resources resolve. The
+# inspec controls assert what's *visible* without the underlying systems
+# (e.g. /etc/oracle-watchdog dir + the consul-service JSON). Real
+# verification happens on live oracle nodes via cinc-client -W.
+# -------------------------------------------------------------------------------
+
+driver:
+  name: vagrant
+  provider: libvirt
+  customize:
+    memory: 512
+    cpus: 1
+
+provisioner:
+  name: chef_zero
+  product_name: cinc
+  product_version: latest
+  install_strategy: once
+  multiple_converge: 1
+  chef_license: accept
+  log_level: warn
+
+verifier:
+  name: inspec
+  format: doc
+
+platforms:
+  - name: debian-12
+    driver:
+      box: generic/debian12
+
+suites: []

--- a/infrastructure/cinc/cookbooks/oracle/recipes/minio_mount.rb
+++ b/infrastructure/cinc/cookbooks/oracle/recipes/minio_mount.rb
@@ -4,46 +4,16 @@
 # Cookbook:: oracle
 # Recipe:: minio_mount
 #
-# Ensures the OCI block volume tagged `minio-data` is persistently
-# mounted at /mnt/minio-data via a UUID-based fstab entry. Without this,
-# a kernel-upgrade reboot leaves the volume detached and MinIO comes up
-# against an empty root-fs stub (the bucket on oracle-arm-2 went missing
-# this way in May 2026).
-#
-# UUID is resolved at converge time via blkid; if no labeled volume is
-# found we skip with a warning rather than raise -- this recipe should
-# be a no-op on nodes where the volume hasn't been attached yet.
+# Wrapper -- mounts the OCI block volume tagged
+# node[:oracle][:minio_mount][:label] at the configured mount point.
+# Work lives in oracle_minio_mount.
 # -------------------------------------------------------------------------------
 
 mm = node[cookbook]['minio_mount']
 
-directory mm['mount_point'] do
-  owner 'root'
-  group 'root'
-  mode  '0755'
-end
-
-# --- Look up the UUID by label at converge time; chef's mount resource needs the bare UUID for device_type :uuid. ---
-blkid = shell_out('blkid', '-t', "LABEL=#{mm['label']}", '-o', 'value', '-s', 'UUID')
-uuid  = blkid.stdout.chomp
-
-if uuid.empty?
-  Chef::Log.warn("oracle::minio_mount: no volume with LABEL=#{mm['label']} found; skipping mount")
-  return
-end
-
-# --- Drop the legacy /dev/sdb fstab entry if it's still there (superseded by the UUID entry). ---
-mount "remove legacy #{mm['legacy_device']} entry at #{mm['mount_point']}" do
-  mount_point mm['mount_point']
-  device      mm['legacy_device']
-  action      :disable
-  only_if     { ::File.read('/etc/fstab').match?(/^#{Regexp.escape(mm['legacy_device'])}\s+#{Regexp.escape(mm['mount_point'])}\s/) }
-end
-
-mount mm['mount_point'] do
-  device      uuid
-  device_type :uuid
-  fstype      mm['fstype']
-  options     mm['options']
-  action      %i(mount enable)
+oracle_minio_mount mm['mount_point'] do
+  label         mm['label']
+  fstype        mm['fstype']
+  options       mm['options']
+  legacy_device mm['legacy_device']
 end

--- a/infrastructure/cinc/cookbooks/oracle/recipes/watchdog.rb
+++ b/infrastructure/cinc/cookbooks/oracle/recipes/watchdog.rb
@@ -4,87 +4,18 @@
 # Cookbook:: oracle
 # Recipe:: watchdog
 #
-# Installs the oracle-watchdog package from the munchbox aptly repo,
-# drops the (currently empty) /etc/oracle-watchdog/config.yaml, wires
-# the systemd Environment= overrides with CONSUL_HTTP_ADDR + ACL token
-# (fetched from Vault), and registers the watchdog as a consul service
-# for prometheus scrape.
-#
-# Per `feedback_vault_fetch_lazy` -- vault_fetch is wrapped in lazy {}
-# so it runs at converge time, after vault_agent::configure has gated
-# on /run/vault-agent/token.
+# Wrapper -- installs + configures oracle-watchdog. Work lives in
+# oracle_watchdog.
 # -------------------------------------------------------------------------------
 
-# --- Pre-resolve here; `cookbook` is shadowed inside template/file blocks. ---
-watchdog = node[cookbook]['watchdog']
+w = node[cookbook]['watchdog']
 
-# --- Wait for apt lock; earlier recipes may still be holding it. ---
-munchbox_base_apt_lock_wait 'oracle_watchdog_install'
-
-apt_package watchdog['package_name'] do
-  action :upgrade
-  notifies :restart, 'service[oracle-watchdog]', :delayed
-end
-
-# --- Config dir + empty config.yaml so the daemon finds it (uses built-in defaults). ---
-directory watchdog['config_dir'] do
-  owner 'root'
-  group 'root'
-  mode  '0755'
-end
-
-template "#{watchdog['config_dir']}/config.yaml" do
-  source 'watchdog-config.yaml.erb'
-  owner  'root'
-  group  'root'
-  mode   '0644'
-  notifies :restart, 'service[oracle-watchdog]', :delayed
-end
-
-# --- Systemd drop-in: CONSUL_HTTP_ADDR + lazy-fetched ACL token. ---
-directory '/etc/systemd/system/oracle-watchdog.service.d' do
-  owner 'root'
-  group 'root'
-  mode  '0755'
-end
-
-template '/etc/systemd/system/oracle-watchdog.service.d/override.conf' do
-  source 'watchdog-systemd-override.conf.erb'
-  owner  'root'
-  group  'root'
-  mode   '0600'
-  sensitive true
-  variables(
-    consul_addr: watchdog['consul_addr'],
-    # --- vault_fetch deferred to converge time (see feedback_vault_fetch_lazy). ---
-    consul_token: lazy { vault_fetch(watchdog['vault_path'], watchdog['vault_field']) }
-  )
-  notifies :run, 'execute[systemctl daemon-reload]', :immediately
-  notifies :restart, 'service[oracle-watchdog]', :delayed
-end
-
-execute 'systemctl daemon-reload' do
-  command 'systemctl daemon-reload'
-  action :nothing
-end
-
-# --- Consul service registration. Consul scans /etc/consul.d/ on SIGHUP; we notify for immediacy. ---
-template watchdog['consul_service_file'] do
-  source 'watchdog-consul-service.json.erb'
-  owner  'consul'
-  group  'consul'
-  mode   '0640'
-  variables(
-    metrics_port: watchdog['metrics_port']
-  )
-  notifies :reload, 'service[consul]', :delayed
-end
-
-service 'oracle-watchdog' do
-  action %i(enable start)
-end
-
-# --- Stub for the reload notify; consul itself is owned by the consul cookbook. ---
-service 'consul' do
-  action :nothing
+oracle_watchdog 'baseline' do
+  package_name         w['package_name']
+  config_dir           w['config_dir']
+  consul_addr          w['consul_addr']
+  metrics_port         w['metrics_port']
+  vault_path           w['vault_path']
+  vault_field          w['vault_field']
+  consul_service_file  w['consul_service_file']
 end

--- a/infrastructure/cinc/cookbooks/oracle/resources/oracle_minio_mount.rb
+++ b/infrastructure/cinc/cookbooks/oracle/resources/oracle_minio_mount.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+# -------------------------------------------------------------------------------
+# Cookbook:: oracle
+# Resource:: oracle_minio_mount
+#
+# Persistently mounts an OCI block volume (looked up by LABEL) at the
+# given mount point via a UUID-based fstab entry. Sweeps the legacy
+# /dev/sdb entry from the pre-UUID era.
+#
+# No-op (warns) when no labeled volume is found, so the resource is safe
+# to declare on every oracle node regardless of whether the block volume
+# is attached yet.
+# -------------------------------------------------------------------------------
+
+unified_mode true
+
+provides :oracle_minio_mount
+
+property :mount_point,   String, name_property: true
+property :label,         String, required: true
+property :fstype,        String, default: 'ext4'
+property :options,       String, default: 'defaults,nofail,_netdev'
+property :legacy_device, String, default: '/dev/sdb'
+
+default_action :mount
+
+action :mount do
+  directory new_resource.mount_point do
+    owner 'root'
+    group 'root'
+    mode  '0755'
+  end
+
+  blkid = shell_out('blkid', '-t', "LABEL=#{new_resource.label}", '-o', 'value', '-s', 'UUID')
+  uuid  = blkid.stdout.chomp
+
+  if uuid.empty?
+    Chef::Log.warn("oracle_minio_mount[#{new_resource.name}]: no volume with LABEL=#{new_resource.label} found; skipping mount")
+    return
+  end
+
+  legacy = new_resource.legacy_device
+  mp     = new_resource.mount_point
+
+  mount "remove legacy #{legacy} entry at #{mp}" do
+    mount_point mp
+    device      legacy
+    action      :disable
+    only_if     { ::File.read('/etc/fstab').match?(/^#{Regexp.escape(legacy)}\s+#{Regexp.escape(mp)}\s/) }
+  end
+
+  mount new_resource.mount_point do
+    device      uuid
+    device_type :uuid
+    fstype      new_resource.fstype
+    options     new_resource.options
+    action      %i(mount enable)
+  end
+end

--- a/infrastructure/cinc/cookbooks/oracle/resources/oracle_watchdog.rb
+++ b/infrastructure/cinc/cookbooks/oracle/resources/oracle_watchdog.rb
@@ -1,0 +1,109 @@
+# frozen_string_literal: true
+
+# -------------------------------------------------------------------------------
+# Cookbook:: oracle
+# Resource:: oracle_watchdog
+#
+# Installs the oracle-watchdog .deb, lays down the (empty) config.yaml,
+# wires the systemd Environment overrides with CONSUL_HTTP_ADDR + a
+# Vault-fetched ACL token, and registers the daemon as a consul service
+# for prometheus scrape.
+#
+# Vault token is fetched via `lazy { vault_fetch(...) }` so the read
+# happens at converge time (after vault_agent::configure has gated on
+# the token sink at /run/vault-agent/token).
+# -------------------------------------------------------------------------------
+
+unified_mode true
+
+provides :oracle_watchdog
+
+property :package_name,         String,        default: 'oracle-watchdog'
+property :config_dir,           String,        default: '/etc/oracle-watchdog'
+property :consul_addr,          String,        default: '127.0.0.1:8500'
+property :metrics_port,         Integer,       default: 9104
+property :vault_path,           String,        default: 'secret/data/consul/oracle-watchdog-token'
+property :vault_field,          String,        default: 'token'
+property :consul_service_file,  String,        default: '/etc/consul.d/oracle-watchdog.json'
+property :service_name,         String,        default: 'oracle-watchdog'
+property :consul_user,          String,        default: 'consul'
+property :consul_group,         String,        default: 'consul'
+
+default_action :configure
+
+action :configure do
+  pkg = new_resource.package_name
+  svc = new_resource.service_name
+
+  munchbox_base_apt_lock_wait "oracle_watchdog_install_#{new_resource.name}"
+
+  apt_package pkg do
+    action :upgrade
+    notifies :restart, "service[#{svc}]", :delayed
+  end
+
+  directory new_resource.config_dir do
+    owner 'root'
+    group 'root'
+    mode  '0755'
+  end
+
+  template "#{new_resource.config_dir}/config.yaml" do
+    source 'watchdog-config.yaml.erb'
+    cookbook 'oracle'
+    owner  'root'
+    group  'root'
+    mode   '0644'
+    notifies :restart, "service[#{svc}]", :delayed
+  end
+
+  directory "/etc/systemd/system/#{svc}.service.d" do
+    owner 'root'
+    group 'root'
+    mode  '0755'
+  end
+
+  override = new_resource
+
+  template "/etc/systemd/system/#{svc}.service.d/override.conf" do
+    source 'watchdog-systemd-override.conf.erb'
+    cookbook 'oracle'
+    owner  'root'
+    group  'root'
+    mode   '0600'
+    sensitive true
+    variables(
+      consul_addr: override.consul_addr,
+      # --- vault_fetch deferred to converge time (see feedback_vault_fetch_lazy). ---
+      consul_token: lazy { vault_fetch(override.vault_path, override.vault_field) }
+    )
+    notifies :run, 'execute[oracle_watchdog daemon-reload]', :immediately
+    notifies :restart, "service[#{svc}]", :delayed
+  end
+
+  execute 'oracle_watchdog daemon-reload' do
+    command 'systemctl daemon-reload'
+    action  :nothing
+  end
+
+  template new_resource.consul_service_file do
+    source 'watchdog-consul-service.json.erb'
+    cookbook 'oracle'
+    owner  new_resource.consul_user
+    group  new_resource.consul_group
+    mode   '0640'
+    variables(
+      metrics_port: new_resource.metrics_port
+    )
+    notifies :reload, 'service[consul]', :delayed
+  end
+
+  service svc do
+    action %i(enable start)
+  end
+
+  # --- Stub so consul reload notify resolves; consul itself is owned by the consul cookbook. ---
+  service 'consul' do
+    action :nothing
+  end
+end

--- a/infrastructure/cinc/cookbooks/oracle/spec/recipes/minio_mount_spec.rb
+++ b/infrastructure/cinc/cookbooks/oracle/spec/recipes/minio_mount_spec.rb
@@ -3,32 +3,36 @@
 require 'spec_helper'
 
 # -------------------------------------------------------------------------------
-# minio_mount recipe spec
-#
-# Covers: blkid UUID lookup, the legacy /dev/sdb fstab cleanup, and the
-# UUID-based mount. blkid is stubbed (chefspec doesn't shell out).
+# minio_mount recipe spec -- steps into oracle_minio_mount to cover the
+# blkid lookup, legacy /dev/sdb cleanup, and the UUID mount. shell_out is
+# stubbed per-provider via chefspec's stubs_for_provider helper.
 # -------------------------------------------------------------------------------
 
 RSpec.describe 'oracle::minio_mount' do
-  # --- Fake shell_out for the blkid lookup; we test both the "found" + "missing" paths ---
-  let(:blkid_result) do
-    instance_double('Mixlib::ShellOut', stdout: "9c4a5d6e-1111-2222-3333-444455556666\n")
-  end
-
   context 'with a labeled volume present' do
     cached(:chef_run) do
-      runner_blkid = instance_double('Mixlib::ShellOut', stdout: "9c4a5d6e-1111-2222-3333-444455556666\n")
-      allow_any_instance_of(Chef::Recipe).to receive(:shell_out).and_return(runner_blkid)
-      ChefSpec::SoloRunner.new.converge('oracle::minio_mount')
+      stubs_for_provider('oracle_minio_mount[/mnt/minio-data]') do |provider|
+        allow(provider).to receive_shell_out(
+          'blkid', '-t', 'LABEL=minio-data', '-o', 'value', '-s', 'UUID',
+          stdout: "9c4a5d6e-1111-2222-3333-444455556666\n"
+        )
+      end
+      allow(::File).to receive(:read).and_call_original
+      allow(::File).to receive(:read).with('/etc/fstab')
+                                     .and_return("/dev/sdb /mnt/minio-data ext4 defaults 0 2\n")
+      ChefSpec::SoloRunner.new(step_into: %w(oracle_minio_mount)).converge('oracle::minio_mount')
     end
 
-    # --- Mount point directory ---
+    it 'declares the oracle_minio_mount wrapping resource' do
+      expect(chef_run).to mount_oracle_minio_mount('/mnt/minio-data')
+        .with(label: 'minio-data', fstype: 'ext4')
+    end
+
     it 'creates the mount point' do
       expect(chef_run).to create_directory('/mnt/minio-data')
         .with(owner: 'root', group: 'root', mode: '0755')
     end
 
-    # --- UUID-based mount lands in fstab + mounted ---
     it 'enables the UUID-based mount in fstab' do
       expect(chef_run).to enable_mount('/mnt/minio-data')
         .with(device: '9c4a5d6e-1111-2222-3333-444455556666',
@@ -42,17 +46,20 @@ RSpec.describe 'oracle::minio_mount' do
         .with(device: '9c4a5d6e-1111-2222-3333-444455556666')
     end
 
-    # --- Legacy /dev/sdb entry is only touched if the fstab regex matches; in chefspec File.read is real, so a synthetic fstab keeps this check trivial ---
-    it 'declares the legacy fstab cleanup' do
-      expect(chef_run.mount('remove legacy /dev/sdb entry at /mnt/minio-data')).to_not be_nil
+    it 'disables the legacy /dev/sdb fstab entry (only_if fstab regex matches)' do
+      expect(chef_run).to disable_mount('remove legacy /dev/sdb entry at /mnt/minio-data')
     end
   end
 
-  context 'with no labeled volume found (recipe is a no-op)' do
+  context 'with no labeled volume found (resource action is a no-op past the mount point)' do
     cached(:chef_run) do
-      empty_blkid = instance_double('Mixlib::ShellOut', stdout: "\n")
-      allow_any_instance_of(Chef::Recipe).to receive(:shell_out).and_return(empty_blkid)
-      ChefSpec::SoloRunner.new.converge('oracle::minio_mount')
+      stubs_for_provider('oracle_minio_mount[/mnt/minio-data]') do |provider|
+        allow(provider).to receive_shell_out(
+          'blkid', '-t', 'LABEL=minio-data', '-o', 'value', '-s', 'UUID',
+          stdout: "\n"
+        )
+      end
+      ChefSpec::SoloRunner.new(step_into: %w(oracle_minio_mount)).converge('oracle::minio_mount')
     end
 
     it 'creates the mount point' do

--- a/infrastructure/cinc/cookbooks/oracle/spec/recipes/watchdog_spec.rb
+++ b/infrastructure/cinc/cookbooks/oracle/spec/recipes/watchdog_spec.rb
@@ -12,17 +12,23 @@ require 'spec_helper'
 # -------------------------------------------------------------------------------
 
 RSpec.describe 'oracle::watchdog' do
-  before do
-    # --- Stub both contexts; lazy{} on the template variables evaluates against Chef::Resource ---
-    allow_any_instance_of(Chef::Recipe).to receive(:vault_fetch).and_return('test-oracle-watchdog-token')
-    allow_any_instance_of(Chef::Resource).to receive(:vault_fetch).and_return('test-oracle-watchdog-token')
+  # vault_fetch is stubbed globally in spec_helper via MunchboxLibVaultFetch module_eval.
+
+  cached(:chef_run) do
+    ChefSpec::SoloRunner.new(step_into: %w(oracle_watchdog)).converge('oracle::watchdog')
   end
 
-  cached(:chef_run) { ChefSpec::SoloRunner.new.converge('oracle::watchdog') }
+  it 'declares the oracle_watchdog wrapping resource' do
+    expect(chef_run).to configure_oracle_watchdog('baseline')
+  end
 
   # --- Package install (apt repo registered by munchbox_base::apt_repo elsewhere in the run_list) ---
   it 'upgrades the oracle-watchdog apt package' do
     expect(chef_run).to upgrade_apt_package('oracle-watchdog')
+  end
+
+  it 'waits for the apt lock before installing oracle-watchdog' do
+    expect(chef_run).to wait_munchbox_base_apt_lock_wait('oracle_watchdog_install_baseline')
   end
 
   # --- Config dir ---
@@ -52,13 +58,13 @@ RSpec.describe 'oracle::watchdog' do
   # --- daemon-reload + watchdog restart fire when the override changes ---
   it 'notifies daemon-reload (immediate) + oracle-watchdog restart (delayed) on override change' do
     template = chef_run.template('/etc/systemd/system/oracle-watchdog.service.d/override.conf')
-    expect(template).to notify('execute[systemctl daemon-reload]').to(:run).immediately
+    expect(template).to notify('execute[oracle_watchdog daemon-reload]').to(:run).immediately
     expect(template).to notify('service[oracle-watchdog]').to(:restart).delayed
   end
 
   # --- Daemon-reload is declared :nothing so it only runs when notified ---
-  it 'declares systemctl daemon-reload as :nothing' do
-    expect(chef_run.execute('systemctl daemon-reload')).to do_nothing
+  it 'declares oracle_watchdog daemon-reload as :nothing' do
+    expect(chef_run.execute('oracle_watchdog daemon-reload')).to do_nothing
   end
 
   # --- Consul service registration; consul user/group exist on oracle nodes already (consul cookbook ran first) ---

--- a/infrastructure/cinc/cookbooks/oracle/spec/spec_helper.rb
+++ b/infrastructure/cinc/cookbooks/oracle/spec/spec_helper.rb
@@ -7,9 +7,21 @@
 
 require 'chefspec'
 
+# --- Load vault_fetch lib so MunchboxLibVaultFetch exists for the stub below ---
+require File.expand_path('../../munchbox_lib/libraries/vault_fetch.rb', __dir__)
+
 Dir[File.expand_path('support/**/*.rb', __dir__)].each { |f| require f }
 
 ChefSpec::Coverage.start! { add_filter 'munchbox_lib' }
+
+# --- Stub vault_fetch via module monkey-patch (only reliable way for lazy{}). ---
+RSpec.configure do |c|
+  c.before(:each) do
+    MunchboxLibVaultFetch.module_eval do
+      define_method(:vault_fetch) { |_path, _field| 'fake-vault-value' }
+    end
+  end
+end
 
 RSpec.configure do |config|
   config.cookbook_path = [

--- a/infrastructure/cinc/cookbooks/vault/.gitignore
+++ b/infrastructure/cinc/cookbooks/vault/.gitignore
@@ -1,0 +1,12 @@
+# --- Test-kitchen state (per-VM logs, vagrant artifacts) ---
+.kitchen/
+kitchen.local.yml
+
+# --- Editor / language-server scratch ---
+.ruby-lsp/
+
+# --- Bundler vendor dir if installed locally ---
+vendor/bundle/
+
+# --- Berkshelf lock file (cookbook dep resolution result) ---
+Berksfile.lock

--- a/infrastructure/cinc/cookbooks/vault/.rubocop.yml
+++ b/infrastructure/cinc/cookbooks/vault/.rubocop.yml
@@ -1,0 +1,26 @@
+# -------------------------------------------------------------------------------
+# Cookstyle (rubocop) config for vault.
+# -------------------------------------------------------------------------------
+
+require:
+  - cookstyle
+
+inherit_gem:
+  cookstyle: config/cookstyle.yml
+
+AllCops:
+  NewCops: enable
+  TargetRubyVersion: 3.1
+  Exclude:
+    - 'Berksfile.lock'
+    - 'Gemfile.lock'
+    - 'tmp/**/*'
+    - 'vendor/**/*'
+
+Layout/LineLength:
+  Max: 120
+
+Metrics/BlockLength:
+  Exclude:
+    - 'spec/**/*'
+    - 'test/**/*'

--- a/infrastructure/cinc/cookbooks/vault/Berksfile
+++ b/infrastructure/cinc/cookbooks/vault/Berksfile
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+source chef_repo: '../..'
+
+metadata

--- a/infrastructure/cinc/cookbooks/vault/Makefile
+++ b/infrastructure/cinc/cookbooks/vault/Makefile
@@ -1,0 +1,51 @@
+# -------------------------------------------------------------------------------
+# Cookbook:: vault
+# Makefile -- delegates to cinc-workstation tools.
+# -------------------------------------------------------------------------------
+
+CHEF      := /usr/local/bin/chef
+COOKSTYLE := /usr/local/bin/cookstyle
+KITCHEN   := /usr/local/bin/kitchen
+
+.PHONY: help tools test lint kitchen create converge verify login destroy
+
+help:
+	@echo "make tools     - install cinc-workstation + libvirt/vagrant stack (one-time host setup)"
+	@echo "make lint      - cookstyle (rubocop with chef cops)"
+	@echo "make test      - chefspec/rspec unit tests"
+	@echo ""
+	@echo "Kitchen lifecycle (run in order, or use 'make kitchen' to do all in one shot):"
+	@echo "  make create    - provision the VM"
+	@echo "  make converge  - run cinc-client on the VM"
+	@echo "  make verify    - run inspec controls against the converged VM"
+	@echo "  make login     - ssh into the VM"
+	@echo "  make destroy   - tear the VM down"
+	@echo ""
+	@echo "  make kitchen   - create + converge + verify + destroy in one go"
+
+tools:
+	../../scripts/kitchen/debian.sh
+
+lint:
+	$(COOKSTYLE) .
+
+test:
+	$(CHEF) exec rspec spec/
+
+kitchen:
+	$(KITCHEN) test
+
+create:
+	$(KITCHEN) create
+
+converge:
+	$(KITCHEN) converge
+
+verify:
+	$(KITCHEN) verify
+
+login:
+	$(KITCHEN) login
+
+destroy:
+	$(KITCHEN) destroy

--- a/infrastructure/cinc/cookbooks/vault/README.md
+++ b/infrastructure/cinc/cookbooks/vault/README.md
@@ -1,0 +1,37 @@
+# vault
+
+Installs + configures HashiCorp Vault **server** (consul storage backend, HA).
+
+Not vault-agent (that's `vault_agent`). Not vault-cert-manager (that's `vault_cert_manager`).
+
+## Recipes
+
+| Recipe | Purpose |
+|---|---|
+| `default` | Empty; opt in via role run_list. |
+| `install` | Vault binary, user/group, dirs. Idempotent on version drift. |
+| `configure` | `vault.hcl` + `vault.service` systemd unit. Renders config but does **not** restart vault (see below). |
+
+## Testing
+
+```
+make lint       # cookstyle
+make test       # chefspec
+make kitchen    # install recipe only -- configure + daemon-start are NOT under kitchen (see below)
+```
+
+### Why kitchen only covers install
+
+The configure recipe + daemon start are intentionally excluded:
+
+- `configure` fetches the consul storage ACL token via `vault_fetch` against a live Vault. There is no usable Vault in a fresh kitchen VM.
+- Vault servers come up **shamir-sealed** (5/3). Any usable test would need the manual unseal flow, which is an operator workflow — not idempotent provisioning. Re-running kitchen would re-seal and stall.
+- `restart_on_change` defaults to `false` for the same reason: a config edit shouldn't bounce a sealed daemon and lock out every tenant.
+
+Test configure changes on a per-node role pointed at a staging vault (`chef-client -W` dry-run), or fold into a planned-maintenance window where the operator is standing by to unseal.
+
+## Operational notes
+
+- Version bump → push cookbook → operator runs `systemctl restart vault` + `vault operator unseal` ×3 per node.
+- TLS cert rotation is handled out-of-band by `vault_cert_manager` (SIGHUP, no unseal needed).
+- The install side adds `vault` to the `consul` group so vault can read `/etc/consul.d/tls/*` (consul-storage backend requires mTLS).

--- a/infrastructure/cinc/cookbooks/vault/attributes/default.rb
+++ b/infrastructure/cinc/cookbooks/vault/attributes/default.rb
@@ -26,13 +26,13 @@
 # -------------------------------------------------------------------------------
 
 default[cookbook]['install'] = {
-  version:    '2.0.1',
-  bin_path:   '/usr/local/bin/vault',
-  user:       'vault',
-  group:      'vault',
+  version: '2.0.1',
+  bin_path: '/usr/local/bin/vault',
+  user: 'vault',
+  group: 'vault',
   config_dir: '/etc/vault.d',
-  data_dir:   '/opt/vault/data',
-  tls_dir:    '/etc/vault.d/tls',
+  data_dir: '/opt/vault/data',
+  tls_dir: '/etc/vault.d/tls',
 }
 
 # -------------------------------------------------------------------------------
@@ -52,41 +52,41 @@ default[cookbook]['install'] = {
 # -------------------------------------------------------------------------------
 
 default[cookbook]['config'] = {
-  cluster_name:    'munchbox-vault',
-  log_level:       'info',
-  ui_enabled:      true,
-  disable_mlock:   false,
+  cluster_name: 'munchbox-vault',
+  log_level: 'info',
+  ui_enabled: true,
+  disable_mlock: false,
 
-  advertise_ip:    nil, # required, per-node
+  advertise_ip: nil, # required, per-node
 
   # --- Listener ---
   listener_address: '0.0.0.0:8200',
   listener_tls_disable: false,
   listener_tls_cert_file: '/etc/vault.d/tls/vault.crt',
-  listener_tls_key_file:  '/etc/vault.d/tls/vault.key',
+  listener_tls_key_file: '/etc/vault.d/tls/vault.key',
 
   # --- Cluster (api_addr / cluster_addr scheme + port; addr IP comes from advertise_ip) ---
-  api_scheme:      'https',
-  api_port:        8200,
-  cluster_port:    8201,
+  api_scheme: 'https',
+  api_port: 8200,
+  cluster_port: 8201,
 
   # --- Consul storage backend ---
-  storage_enabled:    true,
-  storage_address:    '127.0.0.1:8501',
-  storage_scheme:     'https',
-  storage_path:       'vault/',
-  storage_tls_ca_file:   '/etc/consul.d/tls/ca-chain.crt',
+  storage_enabled: true,
+  storage_address: '127.0.0.1:8501',
+  storage_scheme: 'https',
+  storage_path: 'vault/',
+  storage_tls_ca_file: '/etc/consul.d/tls/ca-chain.crt',
   storage_tls_cert_file: '/etc/consul.d/tls/consul.crt',
-  storage_tls_key_file:  '/etc/consul.d/tls/consul.key',
+  storage_tls_key_file: '/etc/consul.d/tls/consul.key',
 
   # --- Service registration (also via consul) ---
   service_registration_enabled: true,
 
   # --- Telemetry ---
-  telemetry_disable_hostname:           false,
-  telemetry_prometheus_retention_time:  '30s',
-  telemetry_usage_gauge_period:         '10m',
-  telemetry_enable_hostname_label:      true,
+  telemetry_disable_hostname: false,
+  telemetry_prometheus_retention_time: '30s',
+  telemetry_usage_gauge_period: '10m',
+  telemetry_enable_hostname_label: true,
 
   # --- Restart safety knob; shamir = manual unseal x3 per restart. Default off; only flip true during planned maintenance windows. ---
   restart_on_change: false,
@@ -105,7 +105,7 @@ default[cookbook]['config'] = {
 
 default[cookbook]['vault_paths'] = {
   consul_storage_token: {
-    path:  'secret/data/consul/vault-storage-token',
+    path: 'secret/data/consul/vault-storage-token',
     field: 'token',
   },
 }

--- a/infrastructure/cinc/cookbooks/vault/kitchen.yml
+++ b/infrastructure/cinc/cookbooks/vault/kitchen.yml
@@ -1,0 +1,49 @@
+---
+# -------------------------------------------------------------------------------
+# Test-Kitchen config for vault.
+#
+# Only exercises the install side -- binary download + user/group/dirs. The
+# configure recipe + vault server start are deliberately NOT under kitchen
+# because:
+#   - configure needs a real consul + vault_fetch'd storage token to even
+#     render vault.hcl (consul isn't deployed in this kitchen).
+#   - the daemon comes up sealed; usable testing would need the unseal x3
+#     flow which is a manual operator workflow, not idempotent provisioning.
+#
+# See README.md for the rationale + how to test configure changes (per-node
+# role + chef-client -W against a staging vault server).
+# -------------------------------------------------------------------------------
+
+driver:
+  name: vagrant
+  provider: libvirt
+  customize:
+    memory: 1024
+    cpus: 1
+
+provisioner:
+  name: chef_zero
+  product_name: cinc
+  product_version: latest
+  install_strategy: once
+  multiple_converge: 2
+  enforce_idempotency: true
+  chef_license: accept
+  log_level: warn
+
+verifier:
+  name: inspec
+  format: doc
+
+platforms:
+  - name: debian-12
+    driver:
+      box: generic/debian12
+
+suites:
+  - name: install
+    run_list:
+      - recipe[vault::install]
+    verifier:
+      inspec_tests:
+        - test/integration/install

--- a/infrastructure/cinc/cookbooks/vault/resources/vault_install.rb
+++ b/infrastructure/cinc/cookbooks/vault/resources/vault_install.rb
@@ -84,7 +84,13 @@ action :install do
     members ['vault']
     append true
     action :modify
-    only_if { ::Etc.getgrnam('consul') rescue false }
+    only_if do
+      begin
+                ::Etc.getgrnam('consul')
+      rescue
+        false
+              end
+    end
   end
 
   # --- Config + data + tls dirs are vault:vault 0750; matches what ansible left. ---

--- a/infrastructure/cinc/cookbooks/vault/spec/recipes/configure_spec.rb
+++ b/infrastructure/cinc/cookbooks/vault/spec/recipes/configure_spec.rb
@@ -1,0 +1,99 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+# -------------------------------------------------------------------------------
+# configure recipe spec. vault_fetch is stubbed globally by spec_helper to
+# return 'fake-vault-value'; specific contexts override via module_eval.
+# -------------------------------------------------------------------------------
+
+RSpec.describe 'vault::configure' do
+  cached(:chef_run) do
+    ChefSpec::SoloRunner.new(step_into: %w(vault_configure)) do |node|
+      node.normal['vault']['config']['advertise_ip'] = '192.168.68.60'
+    end.converge(described_recipe)
+  end
+
+  it 'declares the vault_configure resource keyed by "vault"' do
+    expect(chef_run).to configure_vault_configure('vault')
+      .with(
+        advertise_ip: '192.168.68.60',
+        cluster_name: 'munchbox-vault',
+        api_scheme: 'https',
+        api_port: 8200,
+        cluster_port: 8201,
+        bin_path: '/usr/local/bin/vault',
+        config_dir: '/etc/vault.d',
+        user: 'vault',
+        group: 'vault'
+      )
+  end
+
+  it 'renders /etc/vault.d/vault.hcl as vault:vault 0640' do
+    expect(chef_run).to create_template('/etc/vault.d/vault.hcl')
+      .with(owner: 'vault', group: 'vault', mode: '0640', sensitive: true)
+  end
+
+  it 'wires the consul-storage backend address + token into vault.hcl variables' do
+    tmpl = chef_run.template('/etc/vault.d/vault.hcl')
+    expect(tmpl.variables[:storage_address]).to eq('127.0.0.1:8501')
+    expect(tmpl.variables[:storage_scheme]).to eq('https')
+    expect(tmpl.variables[:storage_path]).to eq('vault/')
+    expect(tmpl.variables[:consul_storage_token]).to eq('fake-vault-value')
+  end
+
+  it 'creates + enables (but does NOT start) the vault.service systemd unit' do
+    # --- start is operator-only because shamir + unseal x3. ---
+    expect(chef_run).to create_systemd_unit('vault.service')
+    expect(chef_run).to enable_systemd_unit('vault.service')
+    expect(chef_run).not_to start_systemd_unit('vault.service')
+  end
+
+  it 'does NOT notify vault.service to restart when restart_on_change is false (the default)' do
+    expect(chef_run.template('/etc/vault.d/vault.hcl'))
+      .not_to notify('systemd_unit[vault.service]').to(:restart)
+  end
+
+  context 'with restart_on_change opt-in (planned-maintenance window)' do
+    let(:restart_run) do
+      ChefSpec::SoloRunner.new(step_into: %w(vault_configure)) do |node|
+        node.normal['vault']['config']['advertise_ip']      = '192.168.68.60'
+        node.normal['vault']['config']['restart_on_change'] = true
+      end.converge(described_recipe)
+    end
+
+    it 'notifies vault.service to restart (delayed) when vault.hcl changes' do
+      expect(restart_run.template('/etc/vault.d/vault.hcl'))
+        .to notify('systemd_unit[vault.service]').to(:restart).delayed
+    end
+  end
+
+  context 'with stale_paths configured' do
+    let(:sweep_run) do
+      ChefSpec::SoloRunner.new(step_into: %w(vault_configure)) do |node|
+        node.normal['vault']['config']['advertise_ip'] = '192.168.68.60'
+        node.normal['vault']['config']['stale_paths']  = ['/etc/vault.d/vault.hcl.bak']
+      end.converge(described_recipe)
+    end
+
+    it 'sweeps each stale path' do
+      expect(sweep_run).to delete_file('/etc/vault.d/vault.hcl.bak')
+    end
+  end
+
+  context 'when the consul-storage token is empty' do
+    before do
+      MunchboxLibVaultFetch.module_eval do
+        define_method(:vault_fetch) { |_path, _field| '' }
+      end
+    end
+
+    it 'raises rather than rendering an unauthenticated vault.hcl' do
+      expect do
+        ChefSpec::SoloRunner.new(step_into: %w(vault_configure)) do |node|
+          node.normal['vault']['config']['advertise_ip'] = '192.168.68.60'
+        end.converge(described_recipe)
+      end.to raise_error(/consul_storage_token cannot be empty/)
+    end
+  end
+end

--- a/infrastructure/cinc/cookbooks/vault/spec/recipes/default_spec.rb
+++ b/infrastructure/cinc/cookbooks/vault/spec/recipes/default_spec.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+# -------------------------------------------------------------------------------
+# default recipe spec -- intentionally empty; opt in via role.
+# -------------------------------------------------------------------------------
+
+RSpec.describe 'vault::default' do
+  cached(:chef_run) { ChefSpec::SoloRunner.new.converge(described_recipe) }
+
+  it 'converges without declaring any resources' do
+    expect(chef_run.resource_collection.map(&:to_s)).to be_empty
+  end
+end

--- a/infrastructure/cinc/cookbooks/vault/spec/recipes/install_spec.rb
+++ b/infrastructure/cinc/cookbooks/vault/spec/recipes/install_spec.rb
@@ -1,0 +1,87 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+# -------------------------------------------------------------------------------
+# install recipe spec -- steps into vault_install so the underlying
+# user/group/dir/remote_file/execute resources are covered.
+# -------------------------------------------------------------------------------
+
+RSpec.describe 'vault::install' do
+  let(:version_check) do
+    "test -x /usr/local/bin/vault && /usr/local/bin/vault version | grep -q 'Vault v2.0.1'"
+  end
+
+  cached(:chef_run) do
+    stub_command(version_check).and_return(false)
+    ChefSpec::SoloRunner.new(step_into: %w(vault_install)).converge(described_recipe)
+  end
+
+  it 'declares the vault_install resource' do
+    expect(chef_run).to install_vault_install('vault')
+      .with(
+        version: '2.0.1',
+        bin_path: '/usr/local/bin/vault',
+        user: 'vault',
+        group: 'vault',
+        config_dir: '/etc/vault.d',
+        data_dir: '/opt/vault/data',
+        tls_dir: '/etc/vault.d/tls'
+      )
+  end
+
+  it 'creates the vault system group' do
+    expect(chef_run).to create_group('vault').with(system: true)
+  end
+
+  it 'creates the vault system user with the no-login shell' do
+    expect(chef_run).to create_user('vault')
+      .with(group: 'vault', system: true, shell: '/bin/false', manage_home: false)
+  end
+
+  it 'creates config + data + tls dirs as vault:vault 0750' do
+    %w(/etc/vault.d /opt/vault/data /etc/vault.d/tls).each do |d|
+      expect(chef_run).to create_directory(d)
+        .with(owner: 'vault', group: 'vault', mode: '0750', recursive: true)
+    end
+  end
+
+  it 'installs unzip (needed to extract the release archive)' do
+    expect(chef_run).to install_package('unzip')
+  end
+
+  it 'fetches the vault release archive' do
+    expect(chef_run).to create_remote_file('/tmp/vault_2.0.1_linux_amd64.zip')
+      .with(source: 'https://releases.hashicorp.com/vault/2.0.1/vault_2.0.1_linux_amd64.zip', mode: '0644')
+  end
+
+  it 'extracts the archive via the install-vault execute resource' do
+    expect(chef_run).to run_execute('install vault 2.0.1')
+  end
+
+  it 'declares the consul-group append (action :modify, only_if-gated)' do
+    # --- group resource is always declared; the only_if guard skips the action
+    #     at run time when consul group doesn't exist on the node.
+    resource = chef_run.find_resources(:group).find { |r| r.name == 'consul' }
+    expect(resource).not_to be_nil
+    expect(resource.members).to eq(['vault'])
+    expect(resource.append).to be true
+  end
+
+  context 'when the vault binary at the pinned version is already on disk' do
+    cached(:idempotent_run) do
+      stub_command(
+        "test -x /usr/local/bin/vault && /usr/local/bin/vault version | grep -q 'Vault v2.0.1'"
+      ).and_return(true)
+      ChefSpec::SoloRunner.new(step_into: %w(vault_install)).converge(described_recipe)
+    end
+
+    it 'skips re-downloading the archive' do
+      expect(idempotent_run.remote_file('/tmp/vault_2.0.1_linux_amd64.zip')).to do_nothing
+    end
+
+    it 'skips re-extracting via the execute resource' do
+      expect(idempotent_run.execute('install vault 2.0.1')).to do_nothing
+    end
+  end
+end

--- a/infrastructure/cinc/cookbooks/vault/spec/spec_helper.rb
+++ b/infrastructure/cinc/cookbooks/vault/spec/spec_helper.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+# -------------------------------------------------------------------------------
+# Cookbook:: vault
+# Spec helper.
+# -------------------------------------------------------------------------------
+
+require 'chefspec'
+
+# Load munchbox_lib's vault_fetch (defines MunchboxLibVaultFetch) before any
+# spec runs so the per-spec stubs below can override its method directly.
+require File.expand_path('../../munchbox_lib/libraries/vault_fetch.rb', __dir__)
+
+Dir[File.expand_path('support/**/*.rb', __dir__)].each { |f| require f }
+
+ChefSpec::Coverage.start! { add_filter 'munchbox_lib' }
+
+# --- Stub vault_fetch globally; modules can't be allow_any_instance_of'd, so
+#     we redefine the method on the module itself per example. Individual specs
+#     can override with their own module_eval to test alternate return values.
+RSpec.configure do |c|
+  c.before(:each) do
+    MunchboxLibVaultFetch.module_eval do
+      define_method(:vault_fetch) { |_path, _field| 'fake-vault-value' }
+    end
+  end
+end
+
+RSpec.configure do |config|
+  config.cookbook_path = [
+    File.expand_path('../../', __dir__),
+    File.expand_path('../../../munchbox_lib', __dir__),
+  ]
+
+  config.platform        = 'debian'
+  config.version         = '12'
+  config.log_level       = :error
+  config.disable_monkey_patching!
+  config.order = :random
+  Kernel.srand(config.seed)
+end

--- a/infrastructure/cinc/cookbooks/vault/spec/support/matchers.rb
+++ b/infrastructure/cinc/cookbooks/vault/spec/support/matchers.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+# -------------------------------------------------------------------------------
+# Custom rspec/chefspec matchers (mirrors munchbox_base/spec/support/matchers.rb)
+# -------------------------------------------------------------------------------
+
+RSpec::Matchers.define :do_nothing do
+  match do |resource|
+    next false unless resource
+
+    ChefSpec::Coverage.cover!(resource)
+    actions = Array(resource.action)
+    actions.include?(:nothing)
+  end
+
+  failure_message do |resource|
+    if resource.nil?
+      'expected a chef resource but got nil'
+    else
+      "expected #{resource} to have action :nothing, got #{Array(resource.action).inspect}"
+    end
+  end
+end

--- a/infrastructure/cinc/cookbooks/vault/test/integration/install/controls/install.rb
+++ b/infrastructure/cinc/cookbooks/vault/test/integration/install/controls/install.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+# -------------------------------------------------------------------------------
+# vault::install integration controls.
+# -------------------------------------------------------------------------------
+
+control 'vault-binary' do
+  impact 1.0
+  title 'vault binary is installed at the expected version + path'
+
+  describe file('/usr/local/bin/vault') do
+    it { should exist }
+    it { should be_executable }
+  end
+
+  describe command('/usr/local/bin/vault version') do
+    its('stdout') { should match(/Vault v2\.0\.1/) }
+    its('exit_status') { should eq 0 }
+  end
+end
+
+control 'vault-user' do
+  impact 1.0
+  title 'vault system user + group exist with the no-login shell'
+
+  describe group('vault') do
+    it { should exist }
+  end
+
+  describe user('vault') do
+    it { should exist }
+    its('group') { should eq 'vault' }
+    its('shell') { should eq '/bin/false' }
+  end
+end
+
+control 'vault-dirs' do
+  impact 1.0
+  title 'vault config + data + tls dirs exist with vault:vault 0750'
+
+  %w(/etc/vault.d /opt/vault/data /etc/vault.d/tls).each do |d|
+    describe directory(d) do
+      it { should exist }
+      its('owner') { should eq 'vault' }
+      its('group') { should eq 'vault' }
+      its('mode')  { should cmp '0750' }
+    end
+  end
+end

--- a/infrastructure/cinc/cookbooks/vault/test/integration/install/inspec.yml
+++ b/infrastructure/cinc/cookbooks/vault/test/integration/install/inspec.yml
@@ -1,0 +1,10 @@
+---
+name: vault-install
+title: vault install integration controls
+maintainer: Alex Freidah
+copyright: Alex Freidah
+license: MIT
+summary: Validates a converged vault::install -- binary, user/group, dirs.
+version: 0.1.0
+supports:
+  - platform: debian

--- a/infrastructure/cinc/cookbooks/vault_agent/resources/vault_agent_configure.rb
+++ b/infrastructure/cinc/cookbooks/vault_agent/resources/vault_agent_configure.rb
@@ -75,11 +75,11 @@ action :configure do
     group  'root'
     mode   '0640'
     variables(
-      vault_addr:     new_resource.vault_addr,
-      auth_mount:     new_resource.auth_mount,
-      sink_path:      new_resource.sink_path,
-      sink_mode:      new_resource.sink_mode,
-      role_id_path:   role_id_path,
+      vault_addr: new_resource.vault_addr,
+      auth_mount: new_resource.auth_mount,
+      sink_path: new_resource.sink_path,
+      sink_mode: new_resource.sink_mode,
+      role_id_path: role_id_path,
       secret_id_path: secret_id_path
     )
     notifies :restart, 'systemd_unit[vault-agent.service]', :delayed

--- a/infrastructure/cinc/cookbooks/vault_agent/spec/recipes/install_spec.rb
+++ b/infrastructure/cinc/cookbooks/vault_agent/spec/recipes/install_spec.rb
@@ -32,4 +32,12 @@ RSpec.describe 'vault_agent::install' do
   it 'waits for the apt lock before touching apt' do
     expect(chef_run).to wait_munchbox_base_apt_lock_wait('vault_agent_install')
   end
+
+  it 'declares the apt_update periodic resource for the hashicorp repo' do
+    expect(chef_run).to periodic_apt_update('vault_agent_install')
+  end
+
+  it 'installs the apt-repo prerequisite packages (gnupg etc.) once' do
+    expect(chef_run).to install_package(%w(gnupg apt-transport-https ca-certificates))
+  end
 end

--- a/infrastructure/cinc/cookbooks/vault_cert_manager/README.md
+++ b/infrastructure/cinc/cookbooks/vault_cert_manager/README.md
@@ -1,0 +1,27 @@
+# vault_cert_manager
+
+Installs + configures `vault-cert-manager` — the long-running daemon that lifecycles infra TLS certs (consul / nomad / vault server certs) out of Vault PKI.
+
+## Recipes
+
+| Recipe | Purpose |
+|---|---|
+| `default` | Empty; opt in via role. |
+| `install` | apt package from the munchbox aptly repo + config dir + cert-owner prereq users (consul, nomad, etc.). |
+| `configure` | AppRole creds + `config.yaml` + systemd drop-in + consul service registration + service start. |
+
+## Testing
+
+```
+make lint
+make test
+make kitchen     # install-only suite (debian-12)
+```
+
+### Why kitchen only covers install
+
+The `configure` recipe needs:
+- Live Vault to `vault_fetch` the AppRole `secret_id`.
+- The cert-manager daemon to actually be able to issue certs (Vault PKI mount + policy in place).
+
+Neither is available in a fresh kitchen guest. Configure changes are tested live on a node (`cinc-client -W` dry-run + service reload).

--- a/infrastructure/cinc/cookbooks/vault_cert_manager/attributes/default.rb
+++ b/infrastructure/cinc/cookbooks/vault_cert_manager/attributes/default.rb
@@ -49,7 +49,7 @@ default[cookbook]['config'] = {
 # -------------------------------------------------------------------------------
 
 default[cookbook]['vault_paths'] = {
-  role_id:   { path: 'secret/data/vault-cert-manager/role-id',   field: 'role_id' },
+  role_id: { path: 'secret/data/vault-cert-manager/role-id', field: 'role_id' },
   secret_id: { path: 'secret/data/vault-cert-manager/secret-id', field: 'secret_id' },
 }
 

--- a/infrastructure/cinc/cookbooks/vault_cert_manager/kitchen.yml
+++ b/infrastructure/cinc/cookbooks/vault_cert_manager/kitchen.yml
@@ -1,0 +1,48 @@
+---
+# -------------------------------------------------------------------------------
+# Test-Kitchen config for vault_cert_manager.
+#
+# Install-only suite: package install + config dir + user/group prereqs.
+# The configure recipe needs a live Vault (AppRole secret_id via vault_fetch)
+# and the cert-manager daemon to actually be able to issue certs -- neither
+# is viable in a fresh kitchen VM. See README.
+#
+# The aptly repo (apt.munchbox.cc) is registered by munchbox_base::apt_repo;
+# the suite's run_list includes that wrapper recipe so the package can
+# resolve.
+# -------------------------------------------------------------------------------
+
+driver:
+  name: vagrant
+  provider: libvirt
+  customize:
+    memory: 1024
+    cpus: 1
+
+provisioner:
+  name: chef_zero
+  product_name: cinc
+  product_version: latest
+  install_strategy: once
+  multiple_converge: 2
+  enforce_idempotency: true
+  chef_license: accept
+  log_level: warn
+
+verifier:
+  name: inspec
+  format: doc
+
+platforms:
+  - name: debian-12
+    driver:
+      box: generic/debian12
+
+suites:
+  - name: install
+    run_list:
+      - recipe[munchbox_base::apt_repo]
+      - recipe[vault_cert_manager::install]
+    verifier:
+      inspec_tests:
+        - test/integration/install

--- a/infrastructure/cinc/cookbooks/vault_cert_manager/spec/recipes/configure_spec.rb
+++ b/infrastructure/cinc/cookbooks/vault_cert_manager/spec/recipes/configure_spec.rb
@@ -22,16 +22,16 @@ RSpec.describe 'vault_cert_manager::configure' do
     ChefSpec::SoloRunner.new do |node|
       node.override['vault_cert_manager']['certificates'] = [
         {
-          'name'        => 'consul-client',
-          'role'        => 'consul-client',
+          'name' => 'consul-client',
+          'role' => 'consul-client',
           'common_name' => 'client.munchbox.consul',
           'certificate' => '/etc/consul.d/tls/consul.crt',
-          'key'         => '/etc/consul.d/tls/consul.key',
-          'ttl'         => '720h',
-          'alt_names'   => %w(localhost test-node),
-          'ip_sans'     => %w(10.200.0.99 127.0.0.1),
-          'owner'       => 'consul',
-          'group'       => 'consul',
+          'key' => '/etc/consul.d/tls/consul.key',
+          'ttl' => '720h',
+          'alt_names' => %w(localhost test-node),
+          'ip_sans' => %w(10.200.0.99 127.0.0.1),
+          'owner' => 'consul',
+          'group' => 'consul',
         },
       ]
     end.converge('vault_cert_manager::configure')

--- a/infrastructure/cinc/cookbooks/vault_cert_manager/spec/recipes/install_spec.rb
+++ b/infrastructure/cinc/cookbooks/vault_cert_manager/spec/recipes/install_spec.rb
@@ -29,4 +29,14 @@ RSpec.describe 'vault_cert_manager::install' do
     expect(chef_run.apt_package('vault-cert-manager'))
       .to notify('service[vault-cert-manager]').to(:restart).delayed
   end
+
+  it 'waits for the apt lock before touching apt' do
+    expect(chef_run).to wait_munchbox_base_apt_lock_wait('vault_cert_manager_install')
+  end
+
+  it 'ensures the consul system group + user exist (cert owner prereq)' do
+    expect(chef_run).to create_group('consul').with(system: true)
+    expect(chef_run).to create_user('consul')
+      .with(group: 'consul', system: true, shell: '/bin/false', manage_home: false)
+  end
 end

--- a/infrastructure/cinc/cookbooks/vault_cert_manager/test/integration/install/controls/install.rb
+++ b/infrastructure/cinc/cookbooks/vault_cert_manager/test/integration/install/controls/install.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+# -------------------------------------------------------------------------------
+# vault_cert_manager::install integration controls.
+# -------------------------------------------------------------------------------
+
+control 'package' do
+  impact 1.0
+  title 'vault-cert-manager apt package is installed'
+
+  describe package('vault-cert-manager') do
+    it { should be_installed }
+  end
+end
+
+control 'binary' do
+  impact 1.0
+  title '/usr/bin/vault-cert-manager binary is on disk + executable'
+
+  describe file('/usr/bin/vault-cert-manager') do
+    it { should exist }
+    it { should be_executable }
+  end
+end
+
+control 'config-dir' do
+  impact 1.0
+  title '/etc/vault-cert-manager exists root:root 0755'
+
+  describe directory('/etc/vault-cert-manager') do
+    it { should exist }
+    its('owner') { should eq 'root' }
+    its('group') { should eq 'root' }
+    its('mode')  { should cmp '0755' }
+  end
+end
+
+control 'consul-user' do
+  impact 1.0
+  title 'consul system user + group exist as cert-owner prereq'
+
+  describe group('consul') do
+    it { should exist }
+  end
+
+  describe user('consul') do
+    it { should exist }
+    its('shell') { should eq '/bin/false' }
+  end
+end

--- a/infrastructure/cinc/cookbooks/vault_cert_manager/test/integration/install/inspec.yml
+++ b/infrastructure/cinc/cookbooks/vault_cert_manager/test/integration/install/inspec.yml
@@ -1,0 +1,10 @@
+---
+name: vault-cert-manager-install
+title: vault-cert-manager install integration controls
+maintainer: Alex Freidah
+copyright: Alex Freidah
+license: MIT
+summary: Validates a converged vault_cert_manager::install -- package, config dir, prereq users.
+version: 0.1.0
+supports:
+  - platform: debian

--- a/infrastructure/cinc/cookbooks/wireguard/spec/recipes/ingress_prereqs_spec.rb
+++ b/infrastructure/cinc/cookbooks/wireguard/spec/recipes/ingress_prereqs_spec.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+# -------------------------------------------------------------------------------
+# ingress_prereqs recipe spec -- steps into wireguard_ingress_prereqs to
+# cover the modules-load drop-in, modprobe execute, package install, and
+# the sysctl-sweep + reload chain.
+# -------------------------------------------------------------------------------
+
+RSpec.describe 'wireguard::ingress_prereqs' do
+  cached(:chef_run) do
+    # --- modprobe guard is shelled out; stub so chefspec doesn't actually exec lsmod ---
+    stub_command('lsmod | grep -q "^wireguard "').and_return(false)
+    ChefSpec::SoloRunner.new(step_into: %w(wireguard_ingress_prereqs)).converge(described_recipe)
+  end
+
+  it 'declares the wireguard_ingress_prereqs resource' do
+    expect(chef_run).to configure_wireguard_ingress_prereqs('baseline')
+  end
+
+  it 'drops the modules-load.d entry so systemd loads wireguard at boot' do
+    expect(chef_run).to create_file('/etc/modules-load.d/wireguard.conf')
+      .with(owner: 'root', group: 'root', mode: '0644', content: "wireguard\n")
+  end
+
+  it 'modprobes wireguard immediately (guarded by lsmod)' do
+    expect(chef_run).to run_execute('modprobe wireguard')
+  end
+
+  it 'installs wireguard-tools for operator wg show access' do
+    expect(chef_run).to install_package('baseline')
+      .with(package_name: %w(wireguard-tools))
+  end
+
+  it 'sweeps the obsolete keepalived-vmac sysctl drop-in' do
+    expect(chef_run).to delete_file('/etc/sysctl.d/99-keepalived-vmac.conf')
+  end
+
+  it 'notifies sysctl --system immediately when a stale sysctl is removed' do
+    expect(chef_run.file('/etc/sysctl.d/99-keepalived-vmac.conf'))
+      .to notify('execute[wireguard ingress sysctl reload]').to(:run).immediately
+  end
+
+  it 'declares the sysctl reload execute (:nothing; only fires on notify)' do
+    expect(chef_run.execute('wireguard ingress sysctl reload')).to do_nothing
+  end
+
+  context 'when wireguard kernel module is already loaded' do
+    cached(:already_loaded_run) do
+      stub_command('lsmod | grep -q "^wireguard "').and_return(true)
+      ChefSpec::SoloRunner.new(step_into: %w(wireguard_ingress_prereqs)).converge(described_recipe)
+    end
+
+    it 'skips modprobe' do
+      expect(already_loaded_run.execute('modprobe wireguard')).to do_nothing
+    end
+  end
+end

--- a/infrastructure/cinc/cookbooks/wireguard/spec/recipes/route_spec.rb
+++ b/infrastructure/cinc/cookbooks/wireguard/spec/recipes/route_spec.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+# -------------------------------------------------------------------------------
+# route recipe spec -- steps into wireguard_route to cover the legacy-path
+# sweep and the wireguard-route.service systemd unit.
+# -------------------------------------------------------------------------------
+
+RSpec.describe 'wireguard::route' do
+  cached(:chef_run) do
+    ChefSpec::SoloRunner.new(step_into: %w(wireguard_route)).converge(described_recipe)
+  end
+
+  it 'declares the wireguard_route resource' do
+    expect(chef_run).to configure_wireguard_route('baseline')
+      .with(network: '10.200.0.0/24', gateway: '192.168.68.49')
+  end
+
+  it 'sweeps the legacy ansible-managed ifupdown file' do
+    expect(chef_run).to delete_file('/etc/network/interfaces.d/wireguard-route')
+  end
+
+  it 'creates + enables + starts the wireguard-route.service oneshot unit' do
+    expect(chef_run).to create_systemd_unit('wireguard-route.service')
+    expect(chef_run).to enable_systemd_unit('wireguard-route.service')
+    expect(chef_run).to start_systemd_unit('wireguard-route.service')
+  end
+
+  it 'bakes the network + gateway into the unit ExecStart' do
+    unit = chef_run.systemd_unit('wireguard-route.service')
+    expect(unit.content).to include('ExecStart=/sbin/ip route replace 10.200.0.0/24 via 192.168.68.49')
+    expect(unit.content).to include('ExecStop=-/sbin/ip route del 10.200.0.0/24 via 192.168.68.49')
+  end
+
+  context 'with the gateway flipped to a different ingress VIP' do
+    cached(:other_run) do
+      ChefSpec::SoloRunner.new(step_into: %w(wireguard_route)) do |node|
+        node.normal['wireguard']['route']['gateway'] = '192.168.68.61'
+      end.converge(described_recipe)
+    end
+
+    it 'bakes the new gateway into the unit ExecStart' do
+      unit = other_run.systemd_unit('wireguard-route.service')
+      expect(unit.content).to include('via 192.168.68.61')
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Closes #112. Brings all 11 in-scope chef cookbooks up to the same testing standard as `munchbox_base`: Makefile, Berksfile, .rubocop.yml, .gitignore, kitchen.yml, README, spec_helper + matchers, full per-recipe chefspec coverage via step_into, and inspec controls where kitchen is viable.

## Per-cookbook delivery

| Cookbook | Specs | Coverage | Notes |
|---|---|---|---|
| vault | 19 | 92.86% | only_if-guarded consul-group modify intentionally untouched |
| cni | 9 | 100% | |
| nvidia | 10 | 100% | kitchen skipped (no GPU in libvirt) |
| nfs | 16 | 100% | 2 kitchen suites (client + server) |
| vault_agent | 18 | 100% | |
| consul | 35 | 100% | |
| nomad | 32 | 100% | incl. auto_restart_webhook |
| wireguard | 28 | 100% | incl. route + ingress_prereqs |
| docker | 26 | 100% | |
| vault_cert_manager | 18 | 100% | kitchen install-only |
| oracle | 21 | 100% | kitchen skipped (needs live Vault + OCI block volume) |

**232 examples, ~98% mean coverage, cookstyle clean across all 11.**

## Notable

- **`oracle` refactored** to the wrapper-recipe + custom-resource pattern. `recipes/{watchdog,minio_mount}.rb` are now one-liners around new `oracle_watchdog` + `oracle_minio_mount` custom resources. Surfaced while writing specs.
- **`vault_fetch` stub fix.** The helper is mixed in via `Chef::DSL::Recipe.include(MunchboxLibVaultFetch)` + `Chef::Resource.include(MunchboxLibVaultFetch)`. `allow_any_instance_of(Object).to receive(:vault_fetch)` does NOT catch lazy-block calls — chef_run hangs in `wait_for_token_sink` (30s poll then raise). Reliable pattern (used in every cookbook that uses vault_fetch): require the library file in spec_helper, then `MunchboxLibVaultFetch.module_eval { define_method(:vault_fetch) { ... } }` in a `before(:each)`.
- **Several pre-existing specs were drifting** against current recipe/resource shape — `consul.service` systemd_unit moved from configure to install, `docker` storage-driver intentionally omitted (would break overlayfs nodes), ubuntu apt-path detection via `/etc/os-release`. All updated to match current behavior.
- Where kitchen genuinely can't run (nvidia: no GPU; oracle: live Vault + OCI; vault: live consul + manual unseal x3), suites are intentionally empty/install-only with the rationale in each cookbook's README.

## Test plan

- [x] `make lint` clean on all 11 cookbooks (cookstyle, zero offenses)
- [x] `make test` passes on all 11 (232 examples, 0 failures)
- [ ] Spot-run `make kitchen` on `cni` + `nfs` (live libvirt) before merge
- [ ] `cinc-client -W` dry-run on a chef-managed node to confirm the oracle resource refactor doesn't drift renders