### PR TITLE
cinc: bump gossip_lan_interval to 10s on goren+stabler

### DIFF
--- a/infrastructure/cinc/nodes/goren.json
+++ b/infrastructure/cinc/nodes/goren.json
@@ -2,10 +2,9 @@
   "name": "goren",
   "chef_environment": "_default",
   "run_list": [
-  "role[bare_metal_pi5]",
-  "role[vault_server]"
-]
-,
+    "role[bare_metal_pi5]",
+    "role[vault_server]"
+  ],
   "normal": {
     "tags": [
       "nomad-server",
@@ -25,7 +24,8 @@
     },
     "consul": {
       "config": {
-        "bind_addr": "192.168.68.60"
+        "bind_addr": "192.168.68.60",
+        "gossip_lan_interval": "10s"
       }
     },
     "vault": {

--- a/infrastructure/cinc/nodes/stabler.json
+++ b/infrastructure/cinc/nodes/stabler.json
@@ -2,11 +2,10 @@
   "name": "stabler",
   "chef_environment": "_default",
   "run_list": [
-  "role[bare_metal_pi5]",
-  "recipe[nomad::auto_restart_webhook]",
-  "role[vault_server]"
-]
-,
+    "role[bare_metal_pi5]",
+    "recipe[nomad::auto_restart_webhook]",
+    "role[vault_server]"
+  ],
   "normal": {
     "tags": [
       "nomad-server",
@@ -26,7 +25,8 @@
     },
     "consul": {
       "config": {
-        "bind_addr": "192.168.68.61"
+        "bind_addr": "192.168.68.61",
+        "gossip_lan_interval": "10s"
       }
     },
     "nomad": {


### PR DESCRIPTION
Per #130, applies the gossip_interval=10s side of the recommended consul agent mitigation, scoped to the two bare-metal Pi5 servers (goren + stabler) that handle most of the cross-WG gossip with the oracle nodes. probe_timeout=5s was already in place from the cookbook default landed in #138/#108.

Other nodes stay on the 1s default — the per-node JSON override is the right scope here.

Verified converge: rendered consul.hcl on both nodes shows the new values, consul restarted cleanly (nomad cascaded as the cookbook intends).

Closes #130.

If flapping returns, easy to either widen the override or revisit the WG-tunnel stabilization angle (which #131 covers separately).