### PR TITLE
pihole-dns: migrate to dklesev/pihole + drop providers/ submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -7,9 +7,6 @@
 [submodule "src/resume"]
 	path = src/resume
 	url = https://github.com/afreidah/resume.git
-[submodule "infrastructure/providers/terraform-provider-pihole"]
-	path = infrastructure/providers/terraform-provider-pihole
-	url = https://github.com/ryanwholey/terraform-provider-pihole.git
 [submodule "src/cloudflare-log-collector"]
 	path = src/cloudflare-log-collector
 	url = https://github.com/afreidah/cloudflare-log-collector.git

--- a/infrastructure/terragrunt/global/pihole-dns/.terraform.lock.hcl
+++ b/infrastructure/terragrunt/global/pihole-dns/.terraform.lock.hcl
@@ -1,9 +1,25 @@
 # This file is maintained automatically by "terraform init".
 # Manual edits may be lost in future updates.
 
+provider "registry.terraform.io/dklesev/pihole" {
+  version     = "1.0.7"
+  constraints = "~> 1.0"
+  hashes = [
+    "h1:yvrDuO2H9jKFn68jI2LOs8jWYjHSM9HVciC+264Oefo=",
+    "zh:0a00a680ffe1cd2e59183df166d8b07e7107a33305ed603dfdb19f35b859b369",
+    "zh:21951899f858e023f2d678a36378ad3bc9eef691d37da0edbf74b69364b549e0",
+    "zh:3d37ac1f238764eb210f18281a2cbf92b2031b9470401f42e09b78973ccf9b35",
+    "zh:699bc28544b2d369ec4ee6c1f0b268a010fa88fb209538eb53504d9eb2c33e27",
+    "zh:69d6ef3eed8c9954587745afe06faefd7da55d5b3b07e595dc5708a9384f1766",
+    "zh:8863a0f450613d48ba3ea8ea6735dde2edad27dfe5001c7a93a15b262043c638",
+    "zh:a33d53acc640dc93b81352ba633cf392bc8c7614a72d320d59d3dcdb22d73fc4",
+    "zh:ba4ce4a83179c00cdb4870de7b3e62d93050dbd6b75ea228a229e59079fc7ca0",
+    "zh:f155326fc97048d1fb5abe3bbe44f00b7cb52c39286c1c2f6f6b108da474fa4c",
+  ]
+}
+
 provider "registry.terraform.io/ryanwholey/pihole" {
-  version     = "0.2.0"
-  constraints = "~> 0.2"
+  version = "0.2.0"
   hashes = [
     "h1:W36nKuGXulE975bvwcRXUlib27z8b71INkvvXbAK/W0=",
     "zh:340bf25085869ef0292ca4c4b916f509e7b3af9bf9c5b4dee9279fdf74287281",

--- a/infrastructure/terragrunt/modules/pihole-dns/main.tf
+++ b/infrastructure/terragrunt/modules/pihole-dns/main.tf
@@ -3,16 +3,11 @@
 # -----------------------------------------------------------------------------
 #
 # Manages local DNS records in Pi-hole for split-horizon DNS. Creates A records
-# and CNAME records on multiple Pi-hole instances to ensure redundancy.
+# (pihole_local_dns) and CNAME records (pihole_cname_record) on both Pi-hole
+# instances (primary = green, secondary = logan) for redundancy.
 #
-# Components Created:
-#   - Pi-hole DNS records (A records) on all instances
-#   - Pi-hole CNAME records on all instances
-#
-# Architecture:
-#   - Records defined via input variables
-#   - Uses Pi-hole API with token authentication
-#   - Manages multiple Pi-hole instances for HA
+# Uses dklesev/pihole (v6 REST API). Inputs keep the caller-facing `.domain`
+# field for back-compat; module remaps it to dklesev's `hostname` arg.
 #
 # Author: Alex Freidah / Project: Munchbox
 # -----------------------------------------------------------------------------
@@ -21,24 +16,24 @@
 # DNS A RECORDS - PRIMARY (green)
 # -----------------------------------------------------------------------------
 
-resource "pihole_dns_record" "primary" {
+resource "pihole_local_dns" "primary" {
   provider = pihole.primary
   for_each = var.dns_records
 
-  domain = each.value.domain
-  ip     = each.value.ip
+  hostname = each.value.domain
+  ip       = each.value.ip
 }
 
 # -----------------------------------------------------------------------------
 # DNS A RECORDS - SECONDARY (logan)
 # -----------------------------------------------------------------------------
 
-resource "pihole_dns_record" "secondary" {
+resource "pihole_local_dns" "secondary" {
   provider = pihole.secondary
   for_each = var.dns_records
 
-  domain = each.value.domain
-  ip     = each.value.ip
+  hostname = each.value.domain
+  ip       = each.value.ip
 }
 
 # -----------------------------------------------------------------------------

--- a/infrastructure/terragrunt/modules/pihole-dns/outputs.tf
+++ b/infrastructure/terragrunt/modules/pihole-dns/outputs.tf
@@ -5,8 +5,8 @@
 output "dns_records_primary" {
   description = "Created DNS A records on primary Pi-hole"
   value = {
-    for k, v in pihole_dns_record.primary : k => {
-      domain = v.domain
+    for k, v in pihole_local_dns.primary : k => {
+      domain = v.hostname
       ip     = v.ip
     }
   }
@@ -15,8 +15,8 @@ output "dns_records_primary" {
 output "dns_records_secondary" {
   description = "Created DNS A records on secondary Pi-hole"
   value = {
-    for k, v in pihole_dns_record.secondary : k => {
-      domain = v.domain
+    for k, v in pihole_local_dns.secondary : k => {
+      domain = v.hostname
       ip     = v.ip
     }
   }

--- a/infrastructure/terragrunt/modules/pihole-dns/tests/default.tftest.hcl
+++ b/infrastructure/terragrunt/modules/pihole-dns/tests/default.tftest.hcl
@@ -40,13 +40,13 @@ run "dns_records_dual_render" {
 
   # --- primary instance gets one record per input ---
   assert {
-    condition     = length(pihole_dns_record.primary) == 2
+    condition     = length(pihole_local_dns.primary) == 2
     error_message = "two dns_records -> two primary A records"
   }
 
   # --- secondary instance gets one record per input ---
   assert {
-    condition     = length(pihole_dns_record.secondary) == 2
+    condition     = length(pihole_local_dns.secondary) == 2
     error_message = "two dns_records -> two secondary A records"
   }
 }
@@ -80,14 +80,14 @@ run "for_each_keys_mirror_input" {
 
   # --- 'alpha' key exists in the primary map ---
   assert {
-    condition     = contains(keys(pihole_dns_record.primary), "alpha")
+    condition     = contains(keys(pihole_local_dns.primary), "alpha")
     error_message = "primary DNS map must have key 'alpha'"
   }
 
-  # --- domain value propagates from input map ---
+  # --- hostname value propagates from input map (input still keyed .domain) ---
   assert {
-    condition     = pihole_dns_record.primary["alpha"].domain == "alpha.test.cc"
-    error_message = "primary alpha record domain must propagate"
+    condition     = pihole_local_dns.primary["alpha"].hostname == "alpha.test.cc"
+    error_message = "primary alpha record hostname must propagate from input .domain"
   }
 }
 
@@ -105,7 +105,7 @@ run "empty_record_maps" {
 
   # --- both Pi-holes have zero A records ---
   assert {
-    condition     = length(pihole_dns_record.primary) == 0 && length(pihole_dns_record.secondary) == 0
+    condition     = length(pihole_local_dns.primary) == 0 && length(pihole_local_dns.secondary) == 0
     error_message = "empty dns_records -> zero A records on both pi-holes"
   }
 

--- a/infrastructure/terragrunt/modules/pihole-dns/versions.tf
+++ b/infrastructure/terragrunt/modules/pihole-dns/versions.tf
@@ -11,8 +11,8 @@ terraform {
 
   required_providers {
     pihole = {
-      source                = "ryanwholey/pihole"
-      version               = "~> 0.2"
+      source                = "dklesev/pihole"
+      version               = "~> 1.0"
       configuration_aliases = [pihole.primary, pihole.secondary]
     }
   }


### PR DESCRIPTION
Last consumer of the vendored `ryanwholey/pihole` fork moves to the registry-published `dklesev/pihole` provider (which `pihole-config` already uses). One pihole provider across all leaves; submodule + dev_overrides go away.

**Module changes:**
- versions.tf: `ryanwholey/pihole ~> 0.2` -> `dklesev/pihole ~> 1.0`
- main.tf: `pihole_dns_record` -> `pihole_local_dns`, `domain` -> `hostname` (CNAME side unchanged, dklesev keeps `pihole_cname_record` schema)
- outputs.tf: track the rename
- tests: assertions updated, still 4/4 passing

**State migration (done out-of-band):**
1. backup state -> /tmp/pihole-dns.tfstate.bak (kept until verified)
2. `state rm` all 72 old `pihole_dns_record.*` entries
3. `terragrunt import` each into `pihole_local_dns.*` (ID format `<ip> <hostname>` per dklesev source)
4. plan verified clean

**Cleanup:**
- `infrastructure/providers/terraform-provider-pihole` submodule removed
- `.gitmodules` entry removed
- After merge: remove the `dev_overrides` block in `~/.terraformrc` by hand

Side note: bumped `webserver.api.max_sessions = 200` on both pi-holes mid-migration to get past the default-10 cap when doing rapid imports. That's runtime config drift right now; could be added to `pihole-config` module's `pihole_config_webserver` if we want it codified — separate issue if so.

Closes #123.