### PR TITLE
pihole-consul: real HTTP probes drive catalog status

### DIFF
--- a/infrastructure/terragrunt/_env_helpers/remote-files.hcl
+++ b/infrastructure/terragrunt/_env_helpers/remote-files.hcl
@@ -6,8 +6,12 @@
 # Branches inside based on the leaf's directory layout:
 #
 #   provider_type == "pihole-consul" → per-host JSON registration leaf
-#     (basename(leaf) = "green"/"logan"); render shared templates from
-#     pihole-consul/_templates/ with that host's IP, ship to one target.
+#     (basename(leaf) = "green"/"logan"); render the shared
+#     pihole-consul/_templates/ with that host's IP, ship the JSONs to
+#     /etc/consul-register/, ship the probe-and-POST consul-register.sh
+#     to /usr/local/bin/, then restart consul-register.service so it
+#     re-runs against the freshest defs (was #30: script now probes
+#     locally each cycle and overrides .Check.Status with real result).
 #
 #   otherwise → static-file leaf (e.g. pihole-shared)
 #     look up bundles in root.hcl's remote_files_configs[node_name], load
@@ -28,15 +32,17 @@ locals {
   provider_type = local.root.locals.provider_type
   leaf_dir      = get_terragrunt_dir()
 
-  # --- pihole-consul: per-host JSONs via templatefile() ---
+  # --- pihole-consul: per-host JSONs + the probe-and-POST script ---
   is_pihole_consul = local.provider_type == "pihole-consul"
   pc_node          = local.is_pihole_consul ? one([for n in local.root.locals.pihole_nodes : n if n.name == local.node_name]) : null
   pc_tmpl_dir      = "${get_repo_root()}/infrastructure/terragrunt/global/pihole-consul/_templates"
   pc_tmpl_vars     = local.is_pihole_consul ? { host = local.pc_node.name, ip = local.pc_node.host } : {}
   pc_files = local.is_pihole_consul ? {
-    "node-exporter.json" = { destination = "/etc/consul-register/node-exporter.json", content = templatefile("${local.pc_tmpl_dir}/node-exporter.json.tmpl", local.pc_tmpl_vars) }
-    "pihole-lb.json"     = { destination = "/etc/consul-register/pihole-lb.json", content = templatefile("${local.pc_tmpl_dir}/pihole-lb.json.tmpl", local.pc_tmpl_vars) }
-    "pihole-webui.json"  = { destination = "/etc/consul-register/pihole-webui.json", content = templatefile("${local.pc_tmpl_dir}/pihole-webui.json.tmpl", local.pc_tmpl_vars) }
+    "node-exporter.json"  = { destination = "/etc/consul-register/node-exporter.json", mode = "0644", content = templatefile("${local.pc_tmpl_dir}/node-exporter.json.tmpl", local.pc_tmpl_vars) }
+    "pihole-lb.json"      = { destination = "/etc/consul-register/pihole-lb.json",     mode = "0644", content = templatefile("${local.pc_tmpl_dir}/pihole-lb.json.tmpl",     local.pc_tmpl_vars) }
+    "pihole-webui.json"   = { destination = "/etc/consul-register/pihole-webui.json",  mode = "0644", content = templatefile("${local.pc_tmpl_dir}/pihole-webui.json.tmpl",  local.pc_tmpl_vars) }
+    # --- The probe-and-POST script; lives next to the JSONs (was bug #30) ---
+    "consul-register.sh"  = { destination = "/usr/local/bin/consul-register.sh",        mode = "0755", content = file("${local.pc_tmpl_dir}/consul-register.sh") }
   } : {}
 
   pihole_consul_inputs = local.is_pihole_consul ? {
@@ -45,10 +51,10 @@ locals {
       consul_register = {
         files = {
           for fk, f in local.pc_files :
-          fk => { content = f.content, destination = f.destination, mode = "0644" }
+          fk => { content = f.content, destination = f.destination, mode = f.mode }
         }
         check_command   = ""
-        restart_command = "systemctl start consul-register.service"
+        restart_command = "systemctl restart consul-register.service"
       }
     }
   } : null

--- a/infrastructure/terragrunt/global/pihole-consul/_templates/consul-register.sh
+++ b/infrastructure/terragrunt/global/pihole-consul/_templates/consul-register.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+# -----------------------------------------------------------------------------
+# Consul Service Registration Script
+#
+# Project: Munchbox / Author: Alex Freidah
+#
+# For each JSON service definition in /etc/consul-register/, probe the
+# embedded .Check.Definition.HTTP locally, build the catalog-register
+# payload with .Check.Status = passing|critical based on the probe, and
+# POST to consul's /v1/catalog/register.
+#
+# Replaces the prior hardcoded-"Status":"passing" pattern (was bug #30).
+# Pi-zero hosts can't run a consul agent, so the probe-and-push happens
+# from this systemd timer instead. Lossy compared to a real agent check
+# but at least the catalog reflects actual reachability within the
+# 5-minute timer interval.
+# -----------------------------------------------------------------------------
+
+set -euo pipefail
+
+CONSUL_ADDR="${CONSUL_ADDR:-http://192.168.68.61:8500}"
+REGISTER_DIR="${REGISTER_DIR:-/etc/consul-register}"
+
+command -v jq >/dev/null || { echo "jq missing; apt-get install -y jq" >&2; exit 1; }
+
+# --- Probe the URL; print passing|critical (warning never used here) ---
+probe_status() {
+  local url=$1 timeout=${2:-5}
+  if curl -sf -o /dev/null -m "$timeout" "$url"; then
+    echo passing
+  else
+    echo critical
+  fi
+}
+
+shopt -s nullglob
+for service_file in "$REGISTER_DIR"/*.json; do
+  name=$(basename "$service_file")
+  url=$(jq -r '.Check.Definition.HTTP // empty' "$service_file")
+  if [[ -z "$url" ]]; then
+    # No check -- POST as-is; consul stores it without a check.
+    payload=$(cat "$service_file")
+    status='(no check)'
+  else
+    status=$(probe_status "$url")
+    payload=$(jq --arg s "$status" '.Check.Status = $s' "$service_file")
+  fi
+
+  echo "Registering $name [status=$status]..."
+  curl -sS -f -o /dev/null \
+    -X PUT -H 'Content-Type: application/json' \
+    -d "$payload" \
+    "$CONSUL_ADDR/v1/catalog/register" \
+    || echo "  POST failed for $name"
+done
+
+echo "Service registration complete for $(hostname -s)"

--- a/infrastructure/terragrunt/global/pihole-consul/_templates/node-exporter.json.tmpl
+++ b/infrastructure/terragrunt/global/pihole-consul/_templates/node-exporter.json.tmpl
@@ -16,5 +16,16 @@
       "role": "dns-server",
       "host": "${host}"
     }
+  },
+  "Check": {
+    "Node": "${host}",
+    "CheckID": "node-exporter-${host}-metrics",
+    "Name": "node-exporter /metrics reachable",
+    "ServiceID": "node-exporter-${host}",
+    "Definition": {
+      "HTTP": "http://${ip}:9100/metrics",
+      "Interval": "30s",
+      "Timeout": "5s"
+    }
   }
 }

--- a/infrastructure/terragrunt/global/pihole-consul/_templates/pihole-lb.json.tmpl
+++ b/infrastructure/terragrunt/global/pihole-consul/_templates/pihole-lb.json.tmpl
@@ -39,7 +39,6 @@
     "Node": "${host}",
     "CheckID": "pihole-lb-${host}-health",
     "Name": "Pi-hole LB Health",
-    "Status": "passing",
     "ServiceID": "pihole-lb-${host}",
     "Definition": {
       "HTTP": "http://${ip}/admin/",

--- a/infrastructure/terragrunt/global/pihole-consul/_templates/pihole-webui.json.tmpl
+++ b/infrastructure/terragrunt/global/pihole-consul/_templates/pihole-webui.json.tmpl
@@ -39,7 +39,6 @@
     "Node": "${host}",
     "CheckID": "pihole-webui-${host}-health",
     "Name": "Pi-hole Web UI Health",
-    "Status": "passing",
     "ServiceID": "pihole-webui-${host}",
     "Definition": {
       "HTTP": "http://${ip}/admin/",


### PR DESCRIPTION
pihole-webui / pihole-lb / node-exporter registrations on green + logan have been forever-`passing` regardless of real state. The catalog-API `register` POST stored the hardcoded `Status` + a `Definition` block that's never executed by anyone. Traefik routed to dead backends; Prometheus scraped phantom node-exporter targets.

Fix: `consul-register.sh` now probes each def's `.Check.Definition.HTTP` locally with `curl -f`, sets `.Check.Status` to passing|critical based on the probe, then POSTs. Templates lose the hardcoded `Status` line; node-exporter template gains a Check block (was registered with no check at all). Pre-existing 5min systemd timer re-runs the script so catalog reflects reality within one cycle.

env_helper wires the new script as a 4th bundle file at mode 0755; `restart_command` bumped from `start` to `restart` so re-shipped scripts run immediately. Per-file mode honored now (was hardcoded 0644 for all).

Verified end-to-end: positive case (both piholes up) reports passing; negative test (probe pointed at a dead URL) flips to critical; restoring the URL returns to passing. Both leaves applied; `terragrunt plan -detailed-exitcode` returns 0 on both.

`jq` already present on both pi-holes -- no extra install step.

Closes #30.