### PR TITLE
Terratest follow-up: prom job fixes + Makefile help sweep

### DIFF
--- a/infrastructure/terragrunt/modules/Makefile
+++ b/infrastructure/terragrunt/modules/Makefile
@@ -5,18 +5,14 @@
 # Per-module logic lives in _common.mk (each module's Makefile is a one-liner
 # `include ../_common.mk`).
 #
-# Usage:
-#   make verify                  # fmt + validate + lint + trivy + checkov + test (every module)
-#   make test                    # terraform test in every module
-#   make lint MODULE=kms-oci     # one module, one target
-#   make fmt-fix                 # rewrite via terraform fmt across all modules
-#   make clean                   # nuke .terraform/ caches everywhere
+# Run `make help` for the current target list. Pass MODULE=<name> to scope
+# any fleet target to a single module.
 #
 # Author: Alex Freidah / Project: Munchbox
 # -----------------------------------------------------------------------------
 
 # --- pihole-dns declares configuration_aliases (pihole.primary, pihole.secondary) ---
-# so it can't be validated standalone — only via its consuming leaf. Skip it.
+# so it can't be validated standalone -- only via its consuming leaf. Skip it.
 SKIP_MODULES := pihole-dns
 MODULES := $(shell find . -mindepth 2 -maxdepth 2 -name Makefile -printf '%h\n' | sed 's|^\./||' | sort | grep -vxF -e $(SKIP_MODULES))
 TARGETS := fmt fmt-fix validate lint trivy checkov test verify clean
@@ -24,20 +20,29 @@ TARGETS := fmt fmt-fix validate lint trivy checkov test verify clean
 .DEFAULT_GOAL := help
 .PHONY: help list $(TARGETS)
 
-help: ## list available targets
-	@echo "Fleet targets (run in every module; pass MODULE=<name> for one):"
-	@for t in $(TARGETS); do printf "  %s\n" "$$t"; done
-	@echo
-	@echo "Meta:"
-	@echo "  list      list discovered modules + targets"
-	@echo "  help      this message"
-	@echo
-	@echo "Examples:"
-	@echo "  make verify                    # everything, every module"
-	@echo "  make test MODULE=kms-oci       # just that module"
-	@echo "  make -C kms-oci help           # per-module help"
+help: ## Display available Make targets
+	@awk 'BEGIN {FS = ":.*##"; printf "\nUsage: make \033[36m<target>\033[0m [MODULE=<name>]\n"} \
+		/^[a-zA-Z0-9_-]+:.*?## / { \
+			gsub(/[A-Z_][A-Z0-9_]*=[a-zA-Z0-9_|-]+/, "\033[33m&\033[0m", $$2); \
+			printf "  \033[36m%-24s\033[0m %s\n", $$1, $$2 \
+		} \
+		/^##@/ {printf "\n\033[1m%s\033[0m\n", substr($$0, 5)}' $(MAKEFILE_LIST)
 
-list:
+##@ Fleet (runs in every module; pass MODULE=<name> for one)
+
+fmt: ## terraform fmt -check across all modules
+fmt-fix: ## terraform fmt (rewrites) across all modules
+validate: ## terraform validate across all modules
+lint: ## tflint across all modules
+trivy: ## trivy config (IaC misconfig scan) across all modules
+checkov: ## checkov (policy/compliance) across all modules
+test: ## terraform test (plan-only suite) across all modules
+verify: ## fmt + validate + lint + test across all modules
+clean: ## remove .terraform/ + lockfile from all modules
+
+##@ Meta
+
+list: ## list discovered modules + fleet targets
 	@echo "modules:"; for m in $(MODULES); do echo "  - $$m"; done; echo; \
 	echo "targets: $(TARGETS)"
 

--- a/infrastructure/terragrunt/modules/_common.mk
+++ b/infrastructure/terragrunt/modules/_common.mk
@@ -5,16 +5,7 @@
 # Run any of these from inside a module dir, or from infrastructure/terragrunt
 # /modules/ to walk every module.
 #
-# Targets:
-#   fmt        terraform fmt -check (read-only)
-#   fmt-fix    terraform fmt (rewrites)
-#   validate   terraform init -backend=false && terraform validate
-#   lint       tflint
-#   trivy      trivy config (IaC misconfig scan)
-#   checkov    checkov (policy/compliance scan)
-#   test       terraform test (plan-only test suite from tests/)
-#   verify     all of the above (fmt, validate, lint, trivy, checkov, test)
-#   clean      remove .terraform/ + lockfile
+# Run `make help` for the current target list.
 #
 # Author: Alex Freidah / Project: Munchbox
 # -----------------------------------------------------------------------------
@@ -22,8 +13,13 @@
 .DEFAULT_GOAL := help
 .PHONY: help fmt fmt-fix validate lint trivy checkov test verify clean init init-tflint
 
-help: ## list available targets
-	@awk 'BEGIN {FS = ":.*?## "} /^[a-zA-Z_-]+:.*?## / {printf "  %-12s %s\n", $$1, $$2}' $(MAKEFILE_LIST) | sort -u
+help: ## Display available Make targets
+	@awk 'BEGIN {FS = ":.*##"; printf "\nUsage: make \033[36m<target>\033[0m\n"} \
+		/^[a-zA-Z0-9_-]+:.*?## / { \
+			gsub(/[A-Z_][A-Z0-9_]*=[a-zA-Z0-9_|-]+/, "\033[33m&\033[0m", $$2); \
+			printf "  \033[36m%-24s\033[0m %s\n", $$1, $$2 \
+		} \
+		/^##@/ {printf "\n\033[1m%s\033[0m\n", substr($$0, 5)}' $(MAKEFILE_LIST)
 
 init:
 	@terraform init -backend=false -upgrade=false -no-color >/dev/null
@@ -31,11 +27,15 @@ init:
 init-tflint:
 	@tflint --init --no-color >/dev/null 2>&1 || true
 
+##@ Format
+
 fmt: ## terraform fmt -check (read-only)
 	@terraform fmt -check -recursive
 
 fmt-fix: ## terraform fmt (rewrites)
 	@terraform fmt -recursive
+
+##@ Validate / Lint
 
 validate: init ## terraform validate (runs init -backend=false first)
 	@terraform validate -no-color
@@ -43,16 +43,22 @@ validate: init ## terraform validate (runs init -backend=false first)
 lint: init-tflint ## tflint (terraform-specific linter)
 	@tflint --no-color --disable-rule=terraform_required_providers
 
+##@ Scan
+
 trivy: ## trivy config (IaC misconfig scan; bundles tfsec/tflint checks)
 	@trivy config --quiet --exit-code 1 .
 
-checkov: ## checkov (policy / compliance scan; skip list in modules/.checkov.yaml)
+checkov: ## checkov (policy/compliance scan; skip list in modules/.checkov.yaml)
 	@checkov --quiet --compact --directory . --framework terraform --config-file ../.checkov.yaml
+
+##@ Test
 
 test: init ## terraform test (plan-only suite from tests/)
 	@terraform test -no-color
 
-verify: fmt validate lint test ## fmt + validate + lint + test (trivy/checkov are plan-time hooks; run ad-hoc if needed)
+verify: fmt validate lint test ## fmt + validate + lint + test (trivy/checkov are ad-hoc)
+
+##@ Maintenance
 
 clean: ## remove .terraform/ + lockfile
 	@rm -rf .terraform .terraform.lock.hcl

--- a/infrastructure/terragrunt/terratest/Makefile
+++ b/infrastructure/terragrunt/terratest/Makefile
@@ -6,11 +6,7 @@
 # folders/keys; they need a real consul/vault/grafana token, sourced from
 # munchbox-env.sh.
 #
-# Targets:
-#   tidy            go mod tidy (sync deps)
-#   test            run every terratest package (parallel-safe)
-#   prometheus-alerts  run just the prometheus-alerts package
-#   clean           strip cache / test binaries
+# Run `make help` for the current target list.
 #
 # Author: Alex Freidah / Project: Munchbox
 # -----------------------------------------------------------------------------
@@ -21,20 +17,31 @@ TEST_FLAGS := -v -timeout 10m -count=1
 .DEFAULT_GOAL := help
 .PHONY: help tidy test prometheus-alerts grafana-dashboards clean
 
-help:  ## list targets
-	@awk 'BEGIN {FS = ":.*?## "} /^[a-zA-Z_-]+:.*?## / {printf "  %-20s %s\n", $$1, $$2}' $(MAKEFILE_LIST) | sort -u
+help: ## Display available Make targets
+	@awk 'BEGIN {FS = ":.*##"; printf "\nUsage: make \033[36m<target>\033[0m\n"} \
+		/^[a-zA-Z0-9_-]+:.*?## / { \
+			gsub(/[A-Z_][A-Z0-9_]*=[a-zA-Z0-9_|-]+/, "\033[33m&\033[0m", $$2); \
+			printf "  \033[36m%-24s\033[0m %s\n", $$1, $$2 \
+		} \
+		/^##@/ {printf "\n\033[1m%s\033[0m\n", substr($$0, 5)}' $(MAKEFILE_LIST)
 
-tidy:  ## go mod tidy (sync deps + go.sum)
+##@ Setup
+
+tidy: ## go mod tidy (sync deps + go.sum)
 	$(GO) mod tidy
 
-test:  ## run every terratest package
+##@ Test
+
+test: ## Run every terratest package
 	$(GO) test $(TEST_FLAGS) ./...
 
-prometheus-alerts:  ## run just the prometheus-alerts package
+prometheus-alerts: ## Run just the prometheus-alerts package
 	$(GO) test $(TEST_FLAGS) ./prometheus_alerts/...
 
-grafana-dashboards:  ## run just the grafana-dashboards package
+grafana-dashboards: ## Run just the grafana-dashboards package
 	$(GO) test $(TEST_FLAGS) ./grafana_dashboards/...
 
-clean:  ## strip test binaries + go build cache
+##@ Maintenance
+
+clean: ## Strip test binaries + go build cache
 	$(GO) clean -testcache

--- a/infrastructure/terragrunt/terratest/prometheus_alerts/prometheus_alerts_test.go
+++ b/infrastructure/terragrunt/terratest/prometheus_alerts/prometheus_alerts_test.go
@@ -47,12 +47,15 @@ const moduleRelativeDir = "../../modules/prometheus-alerts"
 const defaultPrometheusURL = "http://prometheus.service.consul:9090"
 
 // promReloadMaxWait bounds how long we wait for consul-template + SIGHUP to
-// re-render alert_rules.yml and prom to pick up the new group. The template
-// quiescence is ~5s, plus prom config reload, plus slack.
+// re-render alert_rules.yml and prom to pick up the new group. Steady-state
+// latency on this cluster is ~10s (Wait.Min=5s + render + SIGHUP + load);
+// 60s leaves margin for the worst case where consul-template is debouncing
+// other unrelated KV churn under the prometheus/alerts/ prefix.
 const promReloadMaxWait = 60 * time.Second
 
-// promReloadPollInterval is how often we poll /api/v1/rules between checks.
-const promReloadPollInterval = 3 * time.Second
+// promReloadPollInterval matches the client's template_config.Wait.Min
+// (5s) - polling faster than the floor wastes round-trips.
+const promReloadPollInterval = 5 * time.Second
 
 // -------------------------------------------------------------------------
 // TESTS
@@ -90,9 +93,12 @@ func TestPrometheusAlerts_RoundTrip(t *testing.T) {
 
 	// each KV value is a list entry under `groups:` (the consul-template
 	// wraps with `groups:` once); a value of `groups:\n - name: ...` would
-	// render double-`groups:` and break the file
-	val1 := fmt.Sprintf("- name: %s\n  rules: []\n", groupName1)
-	val2 := fmt.Sprintf("- name: %s\n  rules: []\n", groupName2)
+	// render double-`groups:` and break the file. each group needs at least
+	// one rule body - prom silently drops groups with `rules: []`, so a
+	// no-op recording rule is needed to make the group observable via the
+	// /api/v1/rules API.
+	val1 := fmt.Sprintf("- name: %s\n  rules:\n    - record: %s:up\n      expr: vector(1)\n", groupName1, groupName1)
+	val2 := fmt.Sprintf("- name: %s\n  rules:\n    - record: %s:up\n      expr: vector(1)\n", groupName2, groupName2)
 
 	// complex map values don't survive terraform's -var inline parser; pass
 	// via TF_VAR_<name> env var which is auto-parsed as JSON

--- a/nomad/jobs/infrastructure/oracle-watchdog/oracle-watchdog.nomad.hcl
+++ b/nomad/jobs/infrastructure/oracle-watchdog/oracle-watchdog.nomad.hcl
@@ -119,7 +119,7 @@ job "oracle-watchdog" {
 
       # --- Docker Configuration ---
       config {
-        image              = "registry.munchbox.cc/oracle-watchdog:v1.4.4"
+        image              = "registry.munchbox.cc/oracle-watchdog:v1.4.5"
         image_pull_timeout = "5m"
         ports              = ["metrics"]
 

--- a/nomad/jobs/monitoring/prometheus/files/prometheus.yml.tpl
+++ b/nomad/jobs/monitoring/prometheus/files/prometheus.yml.tpl
@@ -14,8 +14,14 @@ storage:
     out_of_order_time_window: 30m
 
 # Alert rules file
+# Read through /local/ (Nomad's built-in alloc-local dir mount) rather than
+# the pack's single-file bind at /etc/prometheus/config/alert_rules.yml.
+# Single-file binds latch to an inode at container start; consul-template's
+# rename-on-write swaps the inode every render, leaving the file mount
+# pointing at the orphaned original. Directory mounts re-resolve per open,
+# so /local/alert_rules.yml always reflects the latest render.
 rule_files:
-  - /etc/prometheus/config/alert_rules.yml
+  - /local/alert_rules.yml
 
 # Alerting configuration - send alerts to Alertmanager via Consul service discovery
 alerting:
@@ -312,7 +318,7 @@ scrape_configs:
     metrics_path: "/api/metrics"
     basic_auth:
       username: "admin"
-      password: "{{ with secret "secret/data/aptly" }}{{ .Data.data.password }}{{ end }}"
+      password: "{{ with secret "secret/data/aptly-admin" }}{{ .Data.data.password }}{{ end }}"
     consul_sd_configs:
       - server: "127.0.0.1:8500"
         scheme: "http"


### PR DESCRIPTION
Follow-up to #134 from running the terratest harness against the live cluster.

## prom job (`prometheus.yml.tpl`)

**aptly scrape was 401** since the secret split — basic_auth was reading from `secret/aptly` (stale 24-char password) instead of `secret/aptly-admin` (what aptly's nginx serves).

**Alert rules updates were silently going nowhere.** The munchbox-service pack emits a single-file Docker bind per template `dest`; consul-template renders via write-temp + rename, which produces a new inode and orphans single-file binds. Templates with `change_mode = signal` (like alert_rules) silently stopped reflecting changes after the first render; `change_mode = restart` ones survive because restart re-resolves the bind. Switched `rule_files` to `/local/alert_rules.yml` — Nomad's built-in alloc-local directory mount is immune to the inode swap. Pack-level fix is still pending for other affected services.

## terratest/prometheus_alerts

- Probe groups include a no-op recording rule (`expr: vector(1)`) — prom silently drops groups with `rules: []` from `/api/v1/rules` even though `promtool` accepts the YAML.
- `promReloadMaxWait` tuned to 60s; poll interval matches the client's `template_config.Wait.Min` (5s).

## Makefile help sweep

`terratest/Makefile`, `modules/Makefile`, and `modules/_common.mk` adopt the s3-orchestrator dynamic help pattern (awk over `\$(MAKEFILE_LIST)` with `##@` section groupings + `##` per-target descriptions). Per-module Makefiles inherit via `include ../_common.mk`. Fleet walker uses target-stub declarations to feed help without breaking the existing `\$(TARGETS)` dispatcher.

Closes #134.