### PR TITLE
temporal: connect via haproxy-postgres consul DNS, drop leader-tracking dance

### DIFF
--- a/nomad/jobs/infrastructure/temporal/files/temporal-env.tpl
+++ b/nomad/jobs/infrastructure/temporal/files/temporal-env.tpl
@@ -1,12 +1,10 @@
 TEMPORAL_BROADCAST_ADDRESS={{ env "NOMAD_IP_http" }}
 TEMPORAL_ADDRESS={{ env "NOMAD_IP_http" }}
 BIND_ON_IP={{ env "NOMAD_IP_http" }}
-{{ $leader := key "service/munchbox-postgres/leader" }}
-{{ $member := key (printf "service/munchbox-postgres/members/%s" $leader) | parseJSON }}
 {{ with secret "secret/data/temporal" }}
 DB=postgres12_pgx
-POSTGRES_SEEDS={{ $member.conn_url | regexReplaceAll "^postgres://" "" | regexReplaceAll ":.*" "" }}
-POSTGRES_PORT=5433
+POSTGRES_SEEDS=haproxy-postgres.service.consul
+DB_PORT=5433
 POSTGRES_USER={{ .Data.data.db_username }}
 POSTGRES_PWD={{ .Data.data.db_password }}
 SQL_TLS_ENABLED=true


### PR DESCRIPTION
Closes #145.

## What

`temporal-env.tpl` now reaches postgres the same way every other service in the cluster does:

```
POSTGRES_SEEDS=haproxy-postgres.service.consul
DB_PORT=5433
```

Removed: the consul-template KV-leader extraction (`service/munchbox-postgres/leader`), the regex-pull-hostname-out-of-conn_url, the implicit `change_mode = restart` on every patroni promotion.

## Why

Two bugs, one stacked on the other:

1. **HAProxy was being bypassed.** `temporalio/server`'s config template reads `DB_PORT`, not `POSTGRES_PORT`. The env was setting `POSTGRES_PORT=5433`, which was silently ignored, and the rendered config fell through to the default `:5432` - connecting directly to patroni, never through HAProxy. So the "HAProxy will kill stale TCP and force reconnect on failover" behavior (the whole point of that infra, from commit 7cb39eb) was never engaged.

2. **The leader-tracking workaround was paving over (1).** Because connections went direct-to-patroni, failover required re-rendering the template to a new leader and restarting temporal. ~30-60s downtime per failover, and the template/regex/restart dance was opaque and brittle.

Once HAProxy is in the path, the right pattern is what every other service uses: just point at the consul DNS name, let pgx + HAProxy handle the rest. pgx resolves the multi-A answer, picks one, connects through HAProxy. On patroni failover HAProxy kills the stale TCP, pgx reconnects (2-5s), HAProxy routes to the new primary. Transparent.

## Verified

After redeploy:
- `env` inside container: `POSTGRES_SEEDS=haproxy-postgres.service.consul`, `DB_PORT=5433`
- `connectAddr` in rendered `docker.yaml`: `haproxy-postgres.service.consul:5433` (for both default and visibility datastores)
- `temporal-server` consul service: passing
- HAProxy logs show traffic flowing `postgres_frontend -> postgres_backend/pg1`
- Task queue managers spinning up workflows in temporal logs

Graceful failover behavior unverified via deliberate switchover (will land naturally next time patroni promotes); architecture is identical to every other working postgres client in the cluster.