### PR TITLE
Upgrade third-party container images (security, patches, majors)

### DIFF
--- a/nomad/jobs/infrastructure/aptly/aptly.nomad.hcl
+++ b/nomad/jobs/infrastructure/aptly/aptly.nomad.hcl
@@ -120,7 +120,7 @@ job "aptly" {
       }
 
       config {
-        image   = "alpine:3.23"
+        image   = "alpine:3.23.4"
         command = "/bin/sh"
         args    = ["/local/setup-gpg.sh"]
 
@@ -191,7 +191,7 @@ echo "GPG key imported successfully (Fingerprint: $FPR)"
       }
 
       config {
-        image   = "alpine:3.23"
+        image   = "alpine:3.23.4"
         command = "/bin/sh"
         args    = ["/local/setup-webui.sh"]
 
@@ -261,7 +261,7 @@ echo "Web UI installed at $WEBUI_DIR"
       }
 
       config {
-        image   = "curlimages/curl:8.18.0"
+        image   = "curlimages/curl:8.20.0"
         command = "/bin/sh"
         args    = ["/local/setup.sh"]
       }

--- a/nomad/jobs/infrastructure/coredns/README.md
+++ b/nomad/jobs/infrastructure/coredns/README.md
@@ -6,7 +6,7 @@ forwarder on port 5354, which each node's dnsmasq uses for non-Consul lookups.
 
 ## Image
 
-`coredns/coredns:1.13.2`
+`coredns/coredns:1.14.3`
 
 ## Hostname / exposure
 

--- a/nomad/jobs/infrastructure/coredns/coredns.nomad.hcl
+++ b/nomad/jobs/infrastructure/coredns/coredns.nomad.hcl
@@ -131,7 +131,7 @@ job "coredns" {
 
       # --- Docker Configuration ---
       config {
-        image        = "coredns/coredns:1.13.2"
+        image        = "coredns/coredns:1.14.3"
         network_mode = "host"
         args         = ["-conf", "/etc/coredns/Corefile"]
         volumes      = [

--- a/nomad/jobs/infrastructure/forgejo-runner/README.md
+++ b/nomad/jobs/infrastructure/forgejo-runner/README.md
@@ -5,7 +5,7 @@ Forgejo server and executes them in Docker containers on the Oracle ARM nodes.
 
 ## image
 
-`gitea/act_runner:0.2.11`
+`gitea/act_runner:0.6.1`
 
 ## hostname / exposure
 

--- a/nomad/jobs/infrastructure/forgejo-runner/forgejo-runner.nomad.hcl
+++ b/nomad/jobs/infrastructure/forgejo-runner/forgejo-runner.nomad.hcl
@@ -95,7 +95,7 @@ job "forgejo-runner" {
       }
 
       config {
-        image        = "gitea/act_runner:0.2.11"
+        image        = "gitea/act_runner:0.6.1"
         network_mode = "host"
         privileged   = true
 

--- a/nomad/jobs/infrastructure/forgejo/README.md
+++ b/nomad/jobs/infrastructure/forgejo/README.md
@@ -5,7 +5,7 @@ runner. All munchbox infra/app code lives here.
 
 ## Image
 
-`codeberg.org/forgejo/forgejo:14.0.3` (plus `busybox:1.37.0` for the prestart
+`codeberg.org/forgejo/forgejo:15.0.2` (plus `busybox:1.38.0` for the prestart
 init-config task)
 
 ## Hostname / exposure

--- a/nomad/jobs/infrastructure/forgejo/forgejo.nomad.hcl
+++ b/nomad/jobs/infrastructure/forgejo/forgejo.nomad.hcl
@@ -191,7 +191,7 @@ job "forgejo" {
       }
 
       config {
-        image   = "busybox:1.37.0"
+        image   = "busybox:1.38.0"
         command = "sh"
         args    = ["-c", "mkdir -p /data/gitea/conf && cp /local/app.ini /data/gitea/conf/app.ini && chown -R 1000:1000 /data/gitea"]
         volumes = [
@@ -338,7 +338,7 @@ EOH
 
       # --- Container Configuration ---
       config {
-        image              = "codeberg.org/forgejo/forgejo:14.0.3"
+        image              = "codeberg.org/forgejo/forgejo:15.0.2"
         image_pull_timeout = "10m"
         ports              = ["http", "ssh"]
         volumes            = [

--- a/nomad/jobs/infrastructure/haproxy/README.md
+++ b/nomad/jobs/infrastructure/haproxy/README.md
@@ -7,7 +7,7 @@ connections on failover so apps reconnect to the new primary.
 
 ## image
 
-`haproxy:3.1-alpine`
+`haproxy:3.2-alpine`
 
 ## hostname / exposure
 

--- a/nomad/jobs/infrastructure/haproxy/haproxy.nomad.hcl
+++ b/nomad/jobs/infrastructure/haproxy/haproxy.nomad.hcl
@@ -224,7 +224,7 @@ job "haproxy" {
 
       # --- Docker Configuration ---
       config {
-        image              = "haproxy:3.1-alpine"
+        image              = "haproxy:3.2-alpine"
         image_pull_timeout = "5m"
         network_mode       = "host"
         volumes = [

--- a/nomad/jobs/infrastructure/keepalived/README.md
+++ b/nomad/jobs/infrastructure/keepalived/README.md
@@ -10,7 +10,7 @@ System job on ingress-role nodes, active/passive with goren as MASTER.
 
 ## Image
 
-`alpine:3.21` (keepalived, curl, wireguard-tools installed at task start)
+`alpine:3.21.7` (keepalived, curl, wireguard-tools installed at task start)
 
 ## Hostname / exposure
 

--- a/nomad/jobs/infrastructure/keepalived/keepalived.nomad.hcl
+++ b/nomad/jobs/infrastructure/keepalived/keepalived.nomad.hcl
@@ -87,7 +87,7 @@ job "keepalived" {
       driver = "docker"
 
       config {
-        image        = "alpine:3.21"
+        image        = "alpine:3.21.7"
         network_mode = "host"
 
         # Required for VRRP and VIP management

--- a/nomad/jobs/infrastructure/minio/README.md
+++ b/nomad/jobs/infrastructure/minio/README.md
@@ -8,7 +8,7 @@ lives outside the homelab.
 
 ## Image
 
-`minio/minio:latest`
+`minio/minio:RELEASE.2025-09-07T16-13-09Z`
 
 ## Hostname / exposure
 

--- a/nomad/jobs/infrastructure/minio/minio.nomad.hcl
+++ b/nomad/jobs/infrastructure/minio/minio.nomad.hcl
@@ -186,7 +186,7 @@ job "minio" {
 
       # --- Docker Configuration ---
       config {
-        image              = "minio/minio:latest"
+        image              = "minio/minio:RELEASE.2025-09-07T16-13-09Z"
         image_pull_timeout = "10m"
         ports              = ["api", "console"]
         network_mode       = "host"

--- a/nomad/jobs/infrastructure/oauth2-proxy/oauth2-proxy.nomad.hcl
+++ b/nomad/jobs/infrastructure/oauth2-proxy/oauth2-proxy.nomad.hcl
@@ -127,7 +127,7 @@ job "oauth2-proxy" {
 
       # --- Container Configuration ---
       config {
-        image              = "quay.io/oauth2-proxy/oauth2-proxy:v7.14.2"
+        image              = "quay.io/oauth2-proxy/oauth2-proxy:v7.15.2"
         image_pull_timeout = "5m"
         network_mode       = "host"
         ports              = ["http"]

--- a/nomad/jobs/infrastructure/patroni/README.md
+++ b/nomad/jobs/infrastructure/patroni/README.md
@@ -7,7 +7,7 @@ HAProxy uses to find the current primary.
 ## image
 
 `registry.munchbox.cc/patroni:pg18`
-(sidecar exporter: `quay.io/prometheuscommunity/postgres-exporter:v0.18.1`)
+(sidecar exporter: `quay.io/prometheuscommunity/postgres-exporter:v0.19.1`)
 
 ## hostname / exposure
 

--- a/nomad/jobs/infrastructure/patroni/patroni.nomad.hcl
+++ b/nomad/jobs/infrastructure/patroni/patroni.nomad.hcl
@@ -211,7 +211,7 @@ job "patroni" {
       driver = "docker"
 
       config {
-        image   = "busybox:1.37.0"
+        image   = "busybox:1.38.0"
         command = "sh"
         args    = ["-c", "mkdir -p /data/pgdata && chown -R 999:999 /data && chmod 700 /data/pgdata"]
         volumes = ["/opt/nomad/data/patroni-${NOMAD_ALLOC_INDEX}:/data"]
@@ -644,7 +644,7 @@ echo "Database initialization complete"
       }
 
       config {
-        image        = "quay.io/prometheuscommunity/postgres-exporter:v0.18.1"
+        image        = "quay.io/prometheuscommunity/postgres-exporter:v0.19.1"
         network_mode = "host"
       }
 

--- a/nomad/jobs/infrastructure/redis-sentinel/README.md
+++ b/nomad/jobs/infrastructure/redis-sentinel/README.md
@@ -6,8 +6,8 @@ Provides cache, session, and queue storage for Forgejo, Trivy Server, etc.
 ## Image
 
 - `redis:8-alpine` (redis server + sentinel)
-- `oliver006/redis_exporter:v1.80.1` (metrics sidecar)
-- `busybox:1.37.0` (prestart init-storage)
+- `oliver006/redis_exporter:v1.84.0` (metrics sidecar)
+- `busybox:1.38.0` (prestart init-storage)
 
 ## Hostname / exposure
 

--- a/nomad/jobs/infrastructure/redis-sentinel/redis-sentinel.nomad.hcl
+++ b/nomad/jobs/infrastructure/redis-sentinel/redis-sentinel.nomad.hcl
@@ -228,7 +228,7 @@ job "redis-sentinel" {
       driver = "docker"
 
       config {
-        image   = "busybox:1.37.0"
+        image   = "busybox:1.38.0"
         command = "sh"
         args    = ["-c", "mkdir -p /data/redis /data/sentinel && rm -f /data/sentinel/sentinel.conf && chown -R 999:999 /data && chmod 700 /data/redis /data/sentinel"]
         volumes = ["/opt/nomad/data/redis-${NOMAD_ALLOC_INDEX}:/data"]
@@ -429,7 +429,7 @@ sentinel announce-port {{ env "NOMAD_PORT_sentinel" }}
       }
 
       config {
-        image        = "oliver006/redis_exporter:v1.80.1"
+        image        = "oliver006/redis_exporter:v1.84.0"
         network_mode = "host"
       }
 

--- a/nomad/jobs/infrastructure/registry/registry-ui.hcl
+++ b/nomad/jobs/infrastructure/registry/registry-ui.hcl
@@ -10,7 +10,7 @@
 # --- Core job configuration ---
 name  = "registry-ui"
 type  = "service"
-image = "joxit/docker-registry-ui@sha256:9e561fbe4fb1460c383e1d33e76f87c4cf4cddfd78adb02db9fb1d039b5c1e15"
+image = "joxit/docker-registry-ui:2.6.0"
 port  = 80
 size = "small"
 

--- a/nomad/jobs/infrastructure/temporal/README.md
+++ b/nomad/jobs/infrastructure/temporal/README.md
@@ -6,7 +6,7 @@ scanning. The server exposes a gRPC API on 7233; the UI is a separate job.
 ## Image
 
 - temporal-server: `temporalio/server:1.29.1`
-- temporal-ui: `temporalio/ui:2.44.1`
+- temporal-ui: `temporalio/ui:2.50.0`
 
 ## Hostname / exposure
 

--- a/nomad/jobs/infrastructure/temporal/temporal-ui.hcl
+++ b/nomad/jobs/infrastructure/temporal/temporal-ui.hcl
@@ -11,7 +11,7 @@
 # --- General Settings ---
 name  = "temporal-ui"
 type  = "service"
-image = "temporalio/ui:2.44.1"
+image = "temporalio/ui:2.50.0"
 port  = 8080
 host_network = true
 size = "small"

--- a/nomad/jobs/infrastructure/traefik/README.md
+++ b/nomad/jobs/infrastructure/traefik/README.md
@@ -8,12 +8,12 @@ service in the cluster routes through here.
 
 ## Image
 
-- traefik: `traefik:v3.6.11`
+- traefik: `traefik:v3.7.1`
 - geoip-updater: `maxmindinc/geoipupdate:v7`
-- traefik-log-filter: `busybox:1.37`
-- traefik-log-agent: `hhftechnology/traefik-log-dashboard-agent:latest`
-- traefik-log-dashboard: `hhftechnology/traefik-log-dashboard:latest`
-- cloudflared-tunnel: `cloudflare/cloudflared:2026.1.2`
+- traefik-log-filter: `busybox:1.38.0`
+- traefik-log-agent: `hhftechnology/traefik-log-dashboard-agent:3.1.1`
+- traefik-log-dashboard: `hhftechnology/traefik-log-dashboard:3.1.1`
+- cloudflared-tunnel: `cloudflare/cloudflared:2026.5.2`
 
 ## Hostname / exposure
 

--- a/nomad/jobs/infrastructure/traefik/traefik.nomad.hcl
+++ b/nomad/jobs/infrastructure/traefik/traefik.nomad.hcl
@@ -123,7 +123,7 @@ job "traefik" {
 
       # --- Docker Configuration ---
       config {
-        image        = "traefik:v3.6.11"
+        image        = "traefik:v3.7.1"
         network_mode = "host"
         ports        = ["http", "https", "dashboard", "gitssh"]
         volumes      = [
@@ -742,7 +742,7 @@ EOH
       }
 
       config {
-        image        = "busybox:1.37"
+        image        = "busybox:1.38.0"
         network_mode = "host"
         # Filter out long-poll/websocket connections that skew response time metrics:
         # - Nomad blocking queries (index=)
@@ -908,7 +908,7 @@ EOH
       }
 
       config {
-        image              = "cloudflare/cloudflared:2026.1.2"
+        image              = "cloudflare/cloudflared:2026.5.2"
         image_pull_timeout = "10m"
         ports              = ["cloudflared-metrics"]
         network_mode       = "host"

--- a/nomad/jobs/infrastructure/trivy-server/README.md
+++ b/nomad/jobs/infrastructure/trivy-server/README.md
@@ -6,7 +6,7 @@ vuln-database downloads and enabling concurrent scans.
 
 ## Image
 
-`aquasec/trivy:0.68.2`
+`aquasec/trivy:0.71.0`
 
 ## Hostname / exposure
 

--- a/nomad/jobs/infrastructure/trivy-server/trivy-server.nomad.hcl
+++ b/nomad/jobs/infrastructure/trivy-server/trivy-server.nomad.hcl
@@ -100,7 +100,7 @@ job "trivy-server" {
       }
 
       config {
-        image              = "aquasec/trivy:0.68.2"
+        image              = "aquasec/trivy:0.71.0"
         image_pull_timeout = "10m"
         ports              = ["http"]
         args               = [

--- a/nomad/jobs/infrastructure/vaultwarden/README.md
+++ b/nomad/jobs/infrastructure/vaultwarden/README.md
@@ -7,7 +7,7 @@ authenticate directly against Vaultwarden.
 
 ## image
 
-`vaultwarden/server:1.35.2`
+`vaultwarden/server:1.36.0`
 
 ## hostname / exposure
 

--- a/nomad/jobs/infrastructure/vaultwarden/vaultwarden.nomad.hcl
+++ b/nomad/jobs/infrastructure/vaultwarden/vaultwarden.nomad.hcl
@@ -94,7 +94,7 @@ job "vaultwarden" {
 
       # --- Container Configuration ---
       config {
-        image              = "vaultwarden/server:1.35.2"
+        image              = "vaultwarden/server:1.36.0"
         image_pull_timeout = "10m"
         ports              = ["http"]
       }

--- a/nomad/jobs/logging/alloy/README.md
+++ b/nomad/jobs/logging/alloy/README.md
@@ -7,7 +7,7 @@ host metrics to Prometheus. Runs on every node.
 
 ## Image
 
-`grafana/alloy:v1.13.2`
+`grafana/alloy:v1.16.2`
 
 ## Hostname / exposure
 

--- a/nomad/jobs/logging/alloy/alloy.nomad.hcl
+++ b/nomad/jobs/logging/alloy/alloy.nomad.hcl
@@ -84,7 +84,7 @@ job "alloy" {
     task "alloy" {
       driver = "docker"
       config {
-        image              = "grafana/alloy:v1.13.2"
+        image              = "grafana/alloy:v1.16.2"
         image_pull_timeout = "10m"
         ports              = ["http"]
         network_mode       = "host"

--- a/nomad/jobs/logging/loki/README.md
+++ b/nomad/jobs/logging/loki/README.md
@@ -6,7 +6,7 @@ Queried via Grafana with LogQL.
 
 ## Image
 
-`grafana/loki:3.6.7`
+`grafana/loki:3.7.2`
 
 ## Hostname / exposure
 

--- a/nomad/jobs/logging/loki/loki.hcl
+++ b/nomad/jobs/logging/loki/loki.hcl
@@ -10,7 +10,7 @@
 
 # --- Core job configuration ---
 name         = "loki"
-image        = "grafana/loki:3.6.7"
+image        = "grafana/loki:3.7.2"
 port         = 3100
 static_port  = 3100
 host_network = true

--- a/nomad/jobs/logging/tempo/README.md
+++ b/nomad/jobs/logging/tempo/README.md
@@ -7,7 +7,7 @@ traces and remote-writes them to Prometheus.
 
 ## Image
 
-`grafana/tempo:2.10.2` (plus `busybox:latest` for init-storage)
+`grafana/tempo:3.0.0` (plus `busybox:1.38.0` for init-storage)
 
 ## Hostname / exposure
 

--- a/nomad/jobs/logging/tempo/tempo.nomad.hcl
+++ b/nomad/jobs/logging/tempo/tempo.nomad.hcl
@@ -127,7 +127,7 @@ job "tempo" {
       driver = "docker"
 
       config {
-        image   = "busybox:latest"
+        image   = "busybox:1.38.0"
         command = "sh"
         args    = ["-c", "mkdir -p /init-data && chown -R 10001:10001 /init-data && chmod 755 /init-data"]
         volumes = [
@@ -148,7 +148,7 @@ job "tempo" {
     task "tempo" {
       driver = "docker"
       config {
-        image              = "grafana/tempo:2.10.2"
+        image              = "grafana/tempo:3.0.0"
         image_pull_timeout = "10m"
         ports              = ["http", "otlp-grpc", "otlp-http", "zipkin", "jaeger-http", "jaeger-grpc"]
         network_mode       = "host"
@@ -160,7 +160,7 @@ job "tempo" {
       }
       template {
         data        = <<EOH
-# Tempo Configuration
+# Tempo Configuration (3.0 architecture: live-store + block-builder + backend-scheduler)
 stream_over_http_enabled: true
 
 server:
@@ -186,16 +186,7 @@ distributor:
         grpc:
           endpoint: 0.0.0.0:14250
 
-# Ingester writes traces to storage
-ingester:
-  max_block_duration: 5m
-
-# Compactor manages trace data lifecycle
-compactor:
-  compaction:
-    block_retention: 72h  # 3 day retention
-
-# Storage configuration (local filesystem)
+# Storage configuration (local filesystem). 3.0 reads existing 2.x blocks automatically.
 storage:
   trace:
     backend: local
@@ -204,19 +195,15 @@ storage:
     local:
       path: /var/tempo/blocks
 
-# Metrics generator for RED metrics from traces
+# Metrics generator for RED metrics from traces.
+# 3.0: the traces_storage block + local_blocks processor are gone; the live-store
+# now serves recent traces internally, so they are no longer configured here.
 metrics_generator:
-  traces_storage:
-    path: /var/tempo/generator/traces
   registry:
     external_labels:
       source: tempo
     collection_interval: 15s
   processor:
-    local_blocks:
-      max_live_traces: 10000
-      flush_check_period: 30s
-      complete_block_timeout: 120s
     service_graphs:
       dimensions: [http.method, http.status_code]
       enable_client_server_prefix: true
@@ -234,11 +221,18 @@ metrics_generator:
 querier:
   max_concurrent_queries: 10
 
-# Overrides for multi-tenant limits
+# Overrides. 3.0: the top-level ingester/compactor blocks were removed; retention and
+# compaction now live here under defaults.compaction.
+# compaction_disabled is a migration shim - the 3.0 compactor cannot compact old 2.x
+# (RF3) blocks, so leave it true until the 2.x blocks age out past block_retention
+# (~3 days), then remove it to re-enable compaction.
 overrides:
   defaults:
+    compaction:
+      block_retention: 72h  # 3 day retention
+      compaction_disabled: true
     metrics_generator:
-      processors: [service-graphs, span-metrics, local-blocks]
+      processors: [service-graphs, span-metrics]
 
 EOH
         destination = "local/config.yaml"

--- a/nomad/jobs/media/cloudflaresolver/README.md
+++ b/nomad/jobs/media/cloudflaresolver/README.md
@@ -5,7 +5,7 @@ on behalf of Prowlarr / *arr indexers.
 
 ## image
 
-`ghcr.io/flaresolverr/flaresolverr:v3.4.6`
+`ghcr.io/flaresolverr/flaresolverr:v3.5.0`
 
 ## hostname / exposure
 

--- a/nomad/jobs/media/cloudflaresolver/cloudflaresolver.hcl
+++ b/nomad/jobs/media/cloudflaresolver/cloudflaresolver.hcl
@@ -10,7 +10,7 @@
 # --- Core job configuration ---
 name         = "cloudflaresolverr"
 type         = "service"
-image        = "ghcr.io/flaresolverr/flaresolverr:v3.4.6"
+image        = "ghcr.io/flaresolverr/flaresolverr:v3.5.0"
 constraints = [
   { attribute = "$${meta.gpu}", operator = "=", value = "true" }
 ]

--- a/nomad/jobs/media/deluge/README.md
+++ b/nomad/jobs/media/deluge/README.md
@@ -7,9 +7,9 @@ tunnel goes down.
 
 ## Image
 
-- gluetun: `qmcgaw/gluetun:v3.41.0`
+- gluetun: `qmcgaw/gluetun:v3.41.1`
 - deluge: `linuxserver/deluge:2.2.0`
-- cleanup-vpn: `alpine:3.21`
+- cleanup-vpn: `alpine:3.21.7`
 
 ## Hostname / exposure
 

--- a/nomad/jobs/media/deluge/deluge.nomad.hcl
+++ b/nomad/jobs/media/deluge/deluge.nomad.hcl
@@ -124,7 +124,7 @@ job "deluge" {
       driver = "docker"
 
       config {
-        image      = "alpine:3.21"
+        image      = "alpine:3.21.7"
         privileged = true
         network_mode = "host"
         command    = "/bin/sh"
@@ -164,7 +164,7 @@ job "deluge" {
       }
 
       config {
-        image      = "qmcgaw/gluetun:v3.41.0"
+        image      = "qmcgaw/gluetun:v3.41.1"
         privileged = true
 
         cap_add = ["NET_ADMIN"]

--- a/nomad/jobs/media/jellyfin/README.md
+++ b/nomad/jobs/media/jellyfin/README.md
@@ -5,7 +5,7 @@ Runs alongside Emby (Emby still owns ErsatzTV/Live TV duty).
 
 ## Image
 
-`jellyfin/jellyfin:10.11.6`
+`jellyfin/jellyfin:10.11.10`
 
 ## Hostname / exposure
 

--- a/nomad/jobs/media/jellyfin/jellyfin.hcl
+++ b/nomad/jobs/media/jellyfin/jellyfin.hcl
@@ -10,7 +10,7 @@
 # --- Core job configuration ---
 name  = "jellyfin"
 type  = "service"
-image = "jellyfin/jellyfin:10.11.6"
+image = "jellyfin/jellyfin:10.11.10"
 port  = 8096
 static_port = 8096
 host_network = true

--- a/nomad/jobs/media/prowlarr/README.md
+++ b/nomad/jobs/media/prowlarr/README.md
@@ -5,7 +5,7 @@ sonarr, radarr, lidarr, and readarr.
 
 ## Image
 
-`linuxserver/prowlarr:2.3.0`
+`linuxserver/prowlarr:2.3.5`
 
 ## Hostname / exposure
 

--- a/nomad/jobs/media/prowlarr/prowlarr.hcl
+++ b/nomad/jobs/media/prowlarr/prowlarr.hcl
@@ -10,7 +10,7 @@
 # --- Core job configuration ---
 name         = "prowlarr"
 type         = "service"
-image        = "linuxserver/prowlarr:2.3.0"
+image        = "linuxserver/prowlarr:2.3.5"
 port         = 9696
 static_port  = 9696
 host_network = true

--- a/nomad/jobs/media/radarr/README.md
+++ b/nomad/jobs/media/radarr/README.md
@@ -5,7 +5,7 @@ grabs off to Deluge.
 
 ## Image
 
-`linuxserver/radarr:6.0.4`
+`linuxserver/radarr:6.1.1`
 
 ## Hostname / exposure
 

--- a/nomad/jobs/media/radarr/radarr.hcl
+++ b/nomad/jobs/media/radarr/radarr.hcl
@@ -10,7 +10,7 @@
 # --- Core job configuration ---
 name         = "radarr"
 type         = "service"
-image        = "linuxserver/radarr:6.0.4"
+image        = "linuxserver/radarr:6.1.1"
 port         = 7878
 static_port  = 7878
 constraints = [

--- a/nomad/jobs/media/sonarr/README.md
+++ b/nomad/jobs/media/sonarr/README.md
@@ -5,7 +5,7 @@ grabs off to Deluge.
 
 ## Image
 
-`linuxserver/sonarr:4.0.16`
+`linuxserver/sonarr:4.0.17`
 
 ## Hostname / exposure
 

--- a/nomad/jobs/media/sonarr/sonarr.hcl
+++ b/nomad/jobs/media/sonarr/sonarr.hcl
@@ -10,7 +10,7 @@
 # --- Core job configuration ---
 name         = "sonarr"
 type         = "service"
-image        = "linuxserver/sonarr:4.0.16"
+image        = "linuxserver/sonarr:4.0.17"
 port         = 8989
 static_port  = 8989
 host_network = true

--- a/nomad/jobs/monitoring/alertmanager/alertmanager.hcl
+++ b/nomad/jobs/monitoring/alertmanager/alertmanager.hcl
@@ -10,7 +10,7 @@
 
 # --- Core job configuration ---
 name  = "alertmanager"
-image = "prom/alertmanager:v0.29.0"
+image = "prom/alertmanager:v0.32.0"
 port  = 9093
 size   = "tiny"
 cpu    = 50

--- a/nomad/jobs/monitoring/grafana/grafana.hcl
+++ b/nomad/jobs/monitoring/grafana/grafana.hcl
@@ -10,7 +10,7 @@
 
 # --- Core job configuration ---
 name         = "grafana"
-image        = "grafana/grafana:12.4.1"
+image        = "grafana/grafana:13.0.1"
 port         = 3030
 host_network = true
 size         = "medium"

--- a/nomad/jobs/monitoring/prometheus/prometheus.hcl
+++ b/nomad/jobs/monitoring/prometheus/prometheus.hcl
@@ -10,7 +10,7 @@
 
 # --- Core job configuration ---
 name  = "prometheus"
-image = "prom/prometheus:v3.10.0"
+image = "prom/prometheus:v3.12.0"
 port  = 9090
 static_port = 9090
 host_network = true

--- a/nomad/jobs/monitoring/pve-exporter/README.md
+++ b/nomad/jobs/monitoring/pve-exporter/README.md
@@ -7,7 +7,7 @@ API. Targets are wired up in Prometheus, this job just exposes
 
 ## Image
 
-`prompve/prometheus-pve-exporter:3.5.0`
+`prompve/prometheus-pve-exporter:3.9.0`
 
 ## Hostname / exposure
 

--- a/nomad/jobs/monitoring/pve-exporter/pve-exporter.hcl
+++ b/nomad/jobs/monitoring/pve-exporter/pve-exporter.hcl
@@ -9,7 +9,7 @@
 
 # --- Core job configuration ---
 name        = "pve-exporter"
-image       = "prompve/prometheus-pve-exporter:3.5.0"
+image       = "prompve/prometheus-pve-exporter:3.9.0"
 port        = 9221
 static_port = 9221
 size        = "tiny"

--- a/nomad/jobs/temporal-workflows/cleanup-worker/cleanup-worker.nomad.hcl
+++ b/nomad/jobs/temporal-workflows/cleanup-worker/cleanup-worker.nomad.hcl
@@ -162,6 +162,9 @@ job "cleanup-worker" {
         {{ with secret "secret/data/backup-worker" }}
         NOMAD_TOKEN={{ .Data.data.nomad_token }}
         {{ end }}
+        {{ with secret "secret/data/postgres-shared/root" }}
+        PGPASSWORD={{ .Data.data.password }}
+        {{ end }}
         EOF
         destination = "secrets/secrets.env"
         env         = true
@@ -175,6 +178,9 @@ job "cleanup-worker" {
         SSH_KEY_PATH                = "/root/.ssh/id_ed25519"
         SSH_CERT_PATH               = "/root/.ssh/id_ed25519-cert.pub"
         SSH_HOST_CA_PATH            = "/root/.ssh/ssh-host-ca.pub"
+        PG_HOST                     = "postgres-primary.service.consul"
+        PG_USER                     = "postgres"
+        PG_SSLMODE                  = "prefer"
         METRICS_LISTEN              = ":9090"
         OTEL_EXPORTER_OTLP_ENDPOINT = "tempo.service.consul:4317"
       }


### PR DESCRIPTION
First pass of the image-upgrade sweep tracked in #150. All deployed and confirmed healthy (one at a time).

## Security / EOL
- haproxy 3.1 -> 3.2-alpine (3.1 EOL), traefik 3.7.1 (CVE-2026-44774) + sidecars, vaultwarden 1.36.0, aptly curl 8.20.0, minio pinned off rolling `latest`.

## Routine patches/minors
- Monitoring, exporters, media stack, and infra sidecars to current stable (alertmanager, alloy, loki, prometheus, coredns, oauth2-proxy, temporal-ui, trivy, the exporters, the *arr stack, jellyfin, registry-ui, gluetun, flaresolverr, busybox/alpine bases).

## Majors
- grafana 13.0.1, forgejo 15.0.2, forgejo-runner (act_runner) 0.6.1.
- **tempo 2.10.2 -> 3.0.0**: config rewritten for the new live-store/block-builder/backend-scheduler architecture via `tempo-cli migrate config`, retention preserved at 72h, validated against the 3.0 binary. **Follow-up:** remove the `compaction_disabled` shim from the tempo config in ~3 days once 2.x blocks age out.

## Not in this PR (still tracked in #150)
- temporal-server 1.31 (needs DB schema migration first; reverted to 1.29.1)
- retired upstreams: readarr, ersatztv, minio long-term
- nginx-s3-gateway rolling-tag pin

Part of #150