### PR TITLE
Temporal maintenance schedules + worker version bumps

### DIFF
--- a/infrastructure/terragrunt/_env_helpers/grafana-dashboards/dashboards/cloudflare-log-collector.json
+++ b/infrastructure/terragrunt/_env_helpers/grafana-dashboards/dashboards/cloudflare-log-collector.json
@@ -1,1681 +1,839 @@
 {
-  "annotations": {
-    "list": [
-      {
-        "builtIn": 1,
-        "datasource": {
-          "type": "grafana",
-          "uid": "-- Grafana --"
-        },
-        "enable": true,
-        "hide": true,
-        "iconColor": "rgba(0, 211, 255, 1)",
-        "name": "Annotations & Alerts",
-        "type": "dashboard"
-      }
-    ]
-  },
-  "editable": true,
-  "fiscalYearStartMonth": 0,
-  "graphTooltip": 0,
-  "id": null,
-  "links": [],
-  "panels": [
-    {
-      "collapsed": false,
-      "gridPos": {
-        "h": 1,
-        "w": 24,
-        "x": 0,
-        "y": 0
-      },
-      "id": 1,
-      "panels": [],
-      "title": "Collector Service Status",
-      "type": "row"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "blue",
-                "value": 0
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 4,
-        "w": 4,
-        "x": 0,
-        "y": 1
-      },
-      "id": 2,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "none",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "percentChangeColorMode": "standard",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "showPercentChange": false,
-        "textMode": "name",
-        "wideLayout": true
-      },
-      "pluginVersion": "12.4.1",
-      "targets": [
-        {
-          "expr": "cflog_build_info",
-          "instant": true,
-          "legendFormat": "{{version}}",
-          "refId": "A"
-        }
-      ],
-      "title": "Version",
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
-      "description": "How often the collector is querying the Cloudflare API",
-      "fieldConfig": {
-        "defaults": {
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": 0
-              }
-            ]
-          },
-          "unit": "reqps"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 4,
-        "w": 4,
-        "x": 4,
-        "y": 1
-      },
-      "id": 3,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "area",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "percentChangeColorMode": "standard",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "showPercentChange": false,
-        "textMode": "value",
-        "wideLayout": true
-      },
-      "pluginVersion": "12.4.1",
-      "targets": [
-        {
-          "expr": "sum(rate(cflog_poll_total{zone=~\"$zone\"}[5m]))",
-          "legendFormat": "polls/s",
-          "refId": "A"
-        }
-      ],
-      "title": "CF API Poll Rate",
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
-      "description": "Failed attempts to query the Cloudflare API",
-      "fieldConfig": {
-        "defaults": {
-          "mappings": [],
-          "noValue": "0",
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": 0
-              },
-              {
-                "color": "yellow",
-                "value": 0.01
-              },
-              {
-                "color": "red",
-                "value": 0.1
-              }
-            ]
-          },
-          "unit": "reqps"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 4,
-        "w": 4,
-        "x": 8,
-        "y": 1
-      },
-      "id": 4,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "area",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "percentChangeColorMode": "standard",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "showPercentChange": false,
-        "textMode": "value",
-        "wideLayout": true
-      },
-      "pluginVersion": "12.4.1",
-      "targets": [
-        {
-          "expr": "sum(rate(cflog_poll_total{zone=~\"$zone\", status=\"error\"}[5m]))",
-          "legendFormat": "errors/s",
-          "refId": "A"
-        }
-      ],
-      "title": "CF API Errors",
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
-      "description": "Seconds since the collector last successfully fetched data from Cloudflare",
-      "fieldConfig": {
-        "defaults": {
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": 0
-              },
-              {
-                "color": "yellow",
-                "value": 360
-              },
-              {
-                "color": "red",
-                "value": 600
-              }
-            ]
-          },
-          "unit": "s"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 4,
-        "w": 4,
-        "x": 12,
-        "y": 1
-      },
-      "id": 5,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "none",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "percentChangeColorMode": "standard",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "showPercentChange": false,
-        "textMode": "value_and_name",
-        "wideLayout": true
-      },
-      "pluginVersion": "12.4.1",
-      "targets": [
-        {
-          "expr": "time() - cflog_last_poll_timestamp{zone=~\"$zone\"}",
-          "legendFormat": "{{dataset}} ({{zone}})",
-          "refId": "A"
-        }
-      ],
-      "title": "Time Since Last Poll",
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
-      "description": "Failed attempts to ship collected data to Loki",
-      "fieldConfig": {
-        "defaults": {
-          "mappings": [],
-          "noValue": "0",
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": 0
-              },
-              {
-                "color": "yellow",
-                "value": 0.01
-              },
-              {
-                "color": "red",
-                "value": 0.1
-              }
-            ]
-          },
-          "unit": "reqps"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 4,
-        "w": 4,
-        "x": 16,
-        "y": 1
-      },
-      "id": 6,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "area",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "percentChangeColorMode": "standard",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "showPercentChange": false,
-        "textMode": "value",
-        "wideLayout": true
-      },
-      "pluginVersion": "12.4.1",
-      "targets": [
-        {
-          "expr": "sum(rate(cflog_loki_push_total{status=\"error\"}[5m]))",
-          "legendFormat": "errors/s",
-          "refId": "A"
-        }
-      ],
-      "title": "Loki Push Errors",
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
-      "description": "How long each Cloudflare API query takes",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisBorderShow": false,
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "barWidthFactor": 0.6,
-            "drawStyle": "line",
-            "fillOpacity": 10,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "insertNulls": false,
-            "lineInterpolation": "linear",
-            "lineWidth": 2,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "showValues": false,
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": 0
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          },
-          "unit": "s"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 6,
-        "w": 8,
-        "x": 0,
-        "y": 5
-      },
-      "id": 7,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "tooltip": {
-          "hideZeros": false,
-          "mode": "multi",
-          "sort": "none"
-        }
-      },
-      "pluginVersion": "12.4.1",
-      "targets": [
-        {
-          "expr": "histogram_quantile(0.99, sum by (le, dataset, zone) (rate(cflog_poll_duration_seconds_bucket{zone=~\"$zone\"}[5m])))",
-          "legendFormat": "p99 {{dataset}} ({{zone}})",
-          "refId": "A"
-        },
-        {
-          "expr": "histogram_quantile(0.50, sum by (le, dataset, zone) (rate(cflog_poll_duration_seconds_bucket{zone=~\"$zone\"}[5m])))",
-          "legendFormat": "p50 {{dataset}} ({{zone}})",
-          "refId": "B"
-        }
-      ],
-      "title": "CF API Poll Duration",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
-      "description": "Rate of log pushes from the collector to Loki",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisBorderShow": false,
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "barWidthFactor": 0.6,
-            "drawStyle": "line",
-            "fillOpacity": 20,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "insertNulls": false,
-            "lineInterpolation": "linear",
-            "lineWidth": 2,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "showValues": false,
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": 0
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          },
-          "unit": "reqps"
-        },
-        "overrides": [
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "error"
-            },
-            "properties": [
-              {
-                "id": "color",
-                "value": {
-                  "fixedColor": "red",
-                  "mode": "fixed"
-                }
-              }
-            ]
-          }
-        ]
-      },
-      "gridPos": {
-        "h": 6,
-        "w": 8,
-        "x": 8,
-        "y": 5
-      },
-      "id": 8,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "tooltip": {
-          "hideZeros": false,
-          "mode": "multi",
-          "sort": "none"
-        }
-      },
-      "pluginVersion": "12.4.1",
-      "targets": [
-        {
-          "expr": "sum by (status) (rate(cflog_loki_push_total[5m]))",
-          "legendFormat": "{{status}}",
-          "refId": "A"
-        }
-      ],
-      "title": "Loki Push Rate",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
-      "description": "How long each push to Loki takes",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisBorderShow": false,
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "barWidthFactor": 0.6,
-            "drawStyle": "line",
-            "fillOpacity": 10,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "insertNulls": false,
-            "lineInterpolation": "linear",
-            "lineWidth": 2,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "showValues": false,
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": 0
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          },
-          "unit": "s"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 6,
-        "w": 8,
-        "x": 16,
-        "y": 5
-      },
-      "id": 9,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "tooltip": {
-          "hideZeros": false,
-          "mode": "multi",
-          "sort": "none"
-        }
-      },
-      "pluginVersion": "12.4.1",
-      "targets": [
-        {
-          "expr": "histogram_quantile(0.99, sum by (le) (rate(cflog_loki_push_duration_seconds_bucket[5m])))",
-          "legendFormat": "p99",
-          "refId": "A"
-        },
-        {
-          "expr": "histogram_quantile(0.50, sum by (le) (rate(cflog_loki_push_duration_seconds_bucket[5m])))",
-          "legendFormat": "p50",
-          "refId": "B"
-        }
-      ],
-      "title": "Loki Push Duration",
-      "type": "timeseries"
-    },
-    {
-      "collapsed": false,
-      "gridPos": {
-        "h": 1,
-        "w": 24,
-        "x": 0,
-        "y": 11
-      },
-      "id": 10,
-      "panels": [],
-      "title": "Web Traffic (from Cloudflare)",
-      "type": "row"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
-      "description": "Total HTTP requests per domain from Cloudflare analytics",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisBorderShow": false,
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "barWidthFactor": 0.6,
-            "drawStyle": "bars",
-            "fillOpacity": 80,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "insertNulls": false,
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "showValues": false,
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "normal"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": 0
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 8,
-        "x": 0,
-        "y": 12
-      },
-      "id": 11,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "tooltip": {
-          "hideZeros": false,
-          "mode": "multi",
-          "sort": "none"
-        }
-      },
-      "pluginVersion": "12.4.1",
-      "targets": [
-        {
-          "expr": "sum by (zone) (cflog_http_requests{zone=~\"$zone\"})",
-          "legendFormat": "{{zone}}",
-          "refId": "A"
-        }
-      ],
-      "title": "Requests by Domain",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
-      "description": "HTTP methods (GET, POST, etc.) across selected domains",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisBorderShow": false,
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "barWidthFactor": 0.6,
-            "drawStyle": "bars",
-            "fillOpacity": 80,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "insertNulls": false,
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "showValues": false,
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "normal"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": 0
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 8,
-        "x": 8,
-        "y": 12
-      },
-      "id": 12,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "tooltip": {
-          "hideZeros": false,
-          "mode": "multi",
-          "sort": "none"
-        }
-      },
-      "pluginVersion": "12.4.1",
-      "targets": [
-        {
-          "expr": "sum by (method) (cflog_http_requests{zone=~\"$zone\"})",
-          "legendFormat": "{{method}}",
-          "refId": "A"
-        }
-      ],
-      "title": "Requests by Method",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
-      "description": "HTTP response status codes across selected domains",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisBorderShow": false,
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "barWidthFactor": 0.6,
-            "drawStyle": "bars",
-            "fillOpacity": 80,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "insertNulls": false,
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "showValues": false,
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "normal"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": 0
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 8,
-        "x": 16,
-        "y": 12
-      },
-      "id": 13,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "tooltip": {
-          "hideZeros": false,
-          "mode": "multi",
-          "sort": "none"
-        }
-      },
-      "pluginVersion": "12.4.1",
-      "targets": [
-        {
-          "expr": "sum by (status) (cflog_http_requests{zone=~\"$zone\"})",
-          "legendFormat": "{{status}}",
-          "refId": "A"
-        }
-      ],
-      "title": "Requests by Status Code",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
-      "description": "Edge response bytes served per domain",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisBorderShow": false,
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "barWidthFactor": 0.6,
-            "drawStyle": "line",
-            "fillOpacity": 20,
-            "gradientMode": "opacity",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "insertNulls": false,
-            "lineInterpolation": "linear",
-            "lineWidth": 2,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "showValues": false,
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": 0
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          },
-          "unit": "decbytes"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 8,
-        "x": 0,
-        "y": 20
-      },
-      "id": 14,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "tooltip": {
-          "hideZeros": false,
-          "mode": "single",
-          "sort": "none"
-        }
-      },
-      "pluginVersion": "12.4.1",
-      "targets": [
-        {
-          "expr": "sum by (zone) (cflog_http_bytes{type=\"edge\", zone=~\"$zone\"})",
-          "legendFormat": "{{zone}}",
-          "refId": "A"
-        }
-      ],
-      "title": "Bandwidth by Domain",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
-      "description": "Where web traffic is coming from, broken out per domain",
-      "fieldConfig": {
-        "defaults": {
-          "custom": {
-            "align": "auto",
-            "cellOptions": {
-              "type": "auto"
-            },
-            "footer": {
-              "reducers": []
-            },
-            "inspect": false
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": 0
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          }
-        },
-        "overrides": [
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "Requests"
-            },
-            "properties": [
-              {
-                "id": "custom.cellOptions",
-                "value": {
-                  "type": "color-background"
-                }
-              },
-              {
-                "id": "thresholds",
-                "value": {
-                  "mode": "absolute",
-                  "steps": [
-                    {
-                      "color": "transparent",
-                      "value": 0
-                    },
-                    {
-                      "color": "super-light-blue",
-                      "value": 5
-                    },
-                    {
-                      "color": "blue",
-                      "value": 50
-                    },
-                    {
-                      "color": "purple",
-                      "value": 500
-                    }
-                  ]
-                }
-              }
-            ]
-          }
-        ]
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 8,
-        "x": 8,
-        "y": 20
-      },
-      "id": 15,
-      "options": {
-        "cellHeight": "sm",
-        "showHeader": true
-      },
-      "pluginVersion": "12.4.1",
-      "targets": [
-        {
-          "expr": "topk(10, sum by (country, zone) (cflog_http_requests{zone=~\"$zone\"}))",
-          "format": "table",
-          "instant": true,
-          "legendFormat": "",
-          "refId": "A"
-        }
-      ],
-      "title": "Visitor Countries by Domain (Top 10)",
-      "transformations": [
-        {
-          "id": "organize",
-          "options": {
-            "excludeByName": {
-              "Time": true,
-              "__name__": true
-            },
-            "indexByName": {
-              "Value": 2,
-              "country": 1,
-              "zone": 0
-            },
-            "renameByName": {
-              "Value": "Requests",
-              "country": "Country",
-              "zone": "Domain"
-            }
-          }
-        },
-        {
-          "id": "sortBy",
-          "options": {
-            "fields": {},
-            "sort": [
-              {
-                "desc": true,
-                "field": "Requests"
-              }
-            ]
-          }
-        }
-      ],
-      "type": "table"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
-      "description": "Per-method, status, country breakdown of web traffic",
-      "fieldConfig": {
-        "defaults": {
-          "custom": {
-            "align": "auto",
-            "cellOptions": {
-              "type": "auto"
-            },
-            "footer": {
-              "reducers": []
-            },
-            "inspect": false
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": 0
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          }
-        },
-        "overrides": [
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "Requests"
-            },
-            "properties": [
-              {
-                "id": "custom.cellOptions",
-                "value": {
-                  "type": "color-background"
-                }
-              },
-              {
-                "id": "thresholds",
-                "value": {
-                  "mode": "absolute",
-                  "steps": [
-                    {
-                      "color": "transparent",
-                      "value": 0
-                    },
-                    {
-                      "color": "blue",
-                      "value": 10
-                    },
-                    {
-                      "color": "purple",
-                      "value": 100
-                    }
-                  ]
-                }
-              }
-            ]
-          }
-        ]
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 8,
-        "x": 16,
-        "y": 20
-      },
-      "id": 16,
-      "options": {
-        "cellHeight": "sm",
-        "showHeader": true
-      },
-      "pluginVersion": "12.4.1",
-      "targets": [
-        {
-          "expr": "sum by (method, status, country) (cflog_http_requests{zone=~\"$zone\"}) > 0",
-          "format": "table",
-          "instant": true,
-          "legendFormat": "",
-          "refId": "A"
-        }
-      ],
-      "title": "Traffic Detail",
-      "transformations": [
-        {
-          "id": "organize",
-          "options": {
-            "excludeByName": {
-              "Time": true,
-              "__name__": true
-            },
-            "renameByName": {
-              "Value": "Requests",
-              "country": "Country",
-              "method": "Method",
-              "status": "Status"
-            }
-          }
-        },
-        {
-          "id": "sortBy",
-          "options": {
-            "fields": {},
-            "sort": [
-              {
-                "desc": true,
-                "field": "Requests"
-              }
-            ]
-          }
-        }
-      ],
-      "type": "table"
-    },
-    {
-      "collapsed": false,
-      "gridPos": {
-        "h": 1,
-        "w": 24,
-        "x": 0,
-        "y": 28
-      },
-      "id": 20,
-      "panels": [],
-      "title": "Firewall Events (from Cloudflare)",
-      "type": "row"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
-      "description": "Firewall actions (block, challenge, etc.) detected by Cloudflare",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisBorderShow": false,
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "barWidthFactor": 0.6,
-            "drawStyle": "bars",
-            "fillOpacity": 80,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "insertNulls": false,
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "showValues": false,
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "normal"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": 0
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          },
-          "unit": "cps"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 0,
-        "y": 29
-      },
-      "id": 21,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "tooltip": {
-          "hideZeros": false,
-          "mode": "multi",
-          "sort": "none"
-        }
-      },
-      "pluginVersion": "12.4.1",
-      "targets": [
-        {
-          "expr": "sum by (action) (rate(cflog_firewall_events_total{zone=~\"$zone\"}[5m]))",
-          "legendFormat": "{{action}}",
-          "refId": "A"
-        }
-      ],
-      "title": "WAF Actions Over Time",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
-      "description": "All-time firewall events since last restart",
-      "fieldConfig": {
-        "defaults": {
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "orange",
-                "value": 0
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 4,
-        "w": 6,
-        "x": 12,
-        "y": 29
-      },
-      "id": 22,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "none",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "percentChangeColorMode": "standard",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "showPercentChange": false,
-        "textMode": "value_and_name",
-        "wideLayout": true
-      },
-      "pluginVersion": "12.4.1",
-      "targets": [
-        {
-          "expr": "sum by (zone) (cflog_firewall_events_total{zone=~\"$zone\"})",
-          "legendFormat": "{{zone}}",
-          "refId": "A"
-        }
-      ],
-      "title": "Total WAF Events",
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
-      "description": "Firewall events grouped by action type",
-      "fieldConfig": {
-        "defaults": {
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "super-light-orange",
-                "value": 0
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 4,
-        "w": 6,
-        "x": 18,
-        "y": 29
-      },
-      "id": 23,
-      "options": {
-        "colorMode": "background",
-        "graphMode": "none",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "percentChangeColorMode": "standard",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "showPercentChange": false,
-        "textMode": "value_and_name",
-        "wideLayout": true
-      },
-      "pluginVersion": "12.4.1",
-      "targets": [
-        {
-          "expr": "sum by (action) (cflog_firewall_events_total{zone=~\"$zone\"})",
-          "legendFormat": "{{action}}",
-          "refId": "A"
-        }
-      ],
-      "title": "WAF Actions Breakdown",
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "loki",
-        "uid": "loki"
-      },
-      "description": "Individual WAF events as shipped to Loki by the collector",
-      "gridPos": {
-        "h": 4,
-        "w": 12,
-        "x": 12,
-        "y": 33
-      },
-      "id": 24,
-      "options": {
-        "dedupStrategy": "none",
-        "enableInfiniteScrolling": false,
-        "enableLogDetails": true,
-        "prettifyLogMessage": true,
-        "showCommonLabels": false,
-        "showControls": false,
-        "showLabels": true,
-        "showTime": true,
-        "sortOrder": "Descending",
-        "unwrappedColumns": false,
-        "wrapLogMessage": false
-      },
-      "pluginVersion": "12.4.1",
-      "targets": [
-        {
-          "expr": "{job=\"cloudflare\", type=\"firewall\", zone=~\"$zone\"} | json",
-          "legendFormat": "",
-          "refId": "A"
-        }
-      ],
-      "title": "Recent Firewall Events (from Loki)",
-      "type": "logs"
-    },
-    {
-      "collapsed": false,
-      "gridPos": {
-        "h": 1,
-        "w": 24,
-        "x": 0,
-        "y": 37
-      },
-      "id": 40,
-      "panels": [],
-      "title": "Collector Logs",
-      "type": "row"
-    },
-    {
-      "datasource": {
-        "type": "loki",
-        "uid": "loki"
-      },
-      "description": "Stdout from the collector itself \u2014 poll results, errors, startup info. Click trace IDs to jump to Tempo.",
-      "gridPos": {
-        "h": 10,
-        "w": 24,
-        "x": 0,
-        "y": 38
-      },
-      "id": 41,
-      "options": {
-        "dedupStrategy": "none",
-        "enableInfiniteScrolling": false,
-        "enableLogDetails": true,
-        "prettifyLogMessage": true,
-        "showCommonLabels": false,
-        "showControls": false,
-        "showLabels": false,
-        "showTime": true,
-        "sortOrder": "Descending",
-        "unwrappedColumns": false,
-        "wrapLogMessage": false
-      },
-      "pluginVersion": "12.4.1",
-      "targets": [
-        {
-          "expr": "{job=\"nomad\", task=\"cloudflare-log-collector\"} | json",
-          "legendFormat": "",
-          "refId": "A"
-        }
-      ],
-      "title": "Service Logs (collector process)",
-      "type": "logs"
-    },
-    {
-      "datasource": {
-        "type": "loki",
-        "uid": "loki"
-      },
-      "description": "The raw HTTP traffic data points that the collector shipped to Loki from Cloudflare analytics",
-      "gridPos": {
-        "h": 8,
-        "w": 24,
-        "x": 0,
-        "y": 48
-      },
-      "id": 42,
-      "options": {
-        "dedupStrategy": "none",
-        "enableInfiniteScrolling": false,
-        "enableLogDetails": true,
-        "prettifyLogMessage": true,
-        "showCommonLabels": false,
-        "showControls": false,
-        "showLabels": true,
-        "showTime": true,
-        "sortOrder": "Descending",
-        "unwrappedColumns": false,
-        "wrapLogMessage": false
-      },
-      "pluginVersion": "12.4.1",
-      "targets": [
-        {
-          "expr": "{job=\"cloudflare\", type=\"http_traffic\", zone=~\"$zone\"} | json",
-          "legendFormat": "",
-          "refId": "A"
-        }
-      ],
-      "title": "HTTP Traffic Logs (raw Cloudflare data in Loki)",
-      "type": "logs"
-    }
-  ],
-  "preload": false,
-  "refresh": "30s",
-  "schemaVersion": 42,
+  "uid": "cloudflare-log-collector",
+  "title": "Cloudflare Log Collector",
   "tags": [
     "cloudflare-log-collector",
     "monitoring"
   ],
-  "templating": {
-    "list": [
-      {
-        "allValue": ".*",
-        "current": {
-          "text": "All",
-          "value": "$__all"
-        },
-        "datasource": {
-          "type": "prometheus",
-          "uid": "prometheus"
-        },
-        "includeAll": true,
-        "label": "Domain",
-        "multi": true,
-        "name": "zone",
-        "options": [],
-        "query": "label_values(cflog_poll_total, zone)",
-        "refresh": 2,
-        "regexApplyTo": "value",
-        "sort": 1,
-        "type": "query"
-      }
-    ]
-  },
+  "timezone": "browser",
+  "schemaVersion": 39,
+  "version": 1,
+  "refresh": "30s",
   "time": {
     "from": "now-1h",
     "to": "now"
   },
-  "timepicker": {},
-  "timezone": "browser",
-  "title": "Cloudflare Log Collector",
-  "uid": "cloudflare-log-collector",
-  "version": 8,
-  "weekStart": ""
+  "panels": [
+    {
+      "type": "row",
+      "id": 1,
+      "title": "Collector Service Status",
+      "gridPos": { "x": 0, "y": 0, "w": 24, "h": 1 },
+      "collapsed": false
+    },
+    {
+      "type": "stat",
+      "id": 2,
+      "title": "Version",
+      "gridPos": { "x": 0, "y": 1, "w": 4, "h": 4 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        {
+          "expr": "cflog_build_info",
+          "legendFormat": "{{version}}",
+          "instant": true
+        }
+      ],
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "textMode": "name",
+        "reduceOptions": { "calcs": ["lastNotNull"] }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [{ "color": "blue", "value": null }]
+          }
+        }
+      }
+    },
+    {
+      "type": "stat",
+      "id": 3,
+      "title": "CF API Poll Rate",
+      "description": "How often the collector is querying the Cloudflare API",
+      "gridPos": { "x": 4, "y": 1, "w": 4, "h": 4 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        {
+          "expr": "sum(rate(cflog_poll_total{zone=~\"$zone\"}[5m]))",
+          "legendFormat": "polls/s"
+        }
+      ],
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "textMode": "value",
+        "reduceOptions": { "calcs": ["lastNotNull"] }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [{ "color": "green", "value": null }]
+          }
+        }
+      }
+    },
+    {
+      "type": "stat",
+      "id": 4,
+      "title": "CF API Errors",
+      "description": "Failed attempts to query the Cloudflare API",
+      "gridPos": { "x": 8, "y": 1, "w": 4, "h": 4 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        {
+          "expr": "sum(rate(cflog_poll_total{zone=~\"$zone\", status=\"error\"}[5m]))",
+          "legendFormat": "errors/s"
+        }
+      ],
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "textMode": "value",
+        "reduceOptions": { "calcs": ["lastNotNull"] }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps",
+          "noValue": "0",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 0.01 },
+              { "color": "red", "value": 0.1 }
+            ]
+          }
+        }
+      }
+    },
+    {
+      "type": "stat",
+      "id": 5,
+      "title": "Time Since Last Poll",
+      "description": "Seconds since the collector last successfully fetched data from Cloudflare",
+      "gridPos": { "x": 12, "y": 1, "w": 4, "h": 4 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        {
+          "expr": "time() - max(cflog_last_poll_timestamp{zone=~\"$zone\"})",
+          "legendFormat": "since last poll"
+        }
+      ],
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "textMode": "value",
+        "reduceOptions": { "calcs": ["lastNotNull"] }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 360 },
+              { "color": "red", "value": 600 }
+            ]
+          }
+        }
+      }
+    },
+    {
+      "type": "stat",
+      "id": 6,
+      "title": "Loki Push Errors",
+      "description": "Failed attempts to ship collected data to Loki",
+      "gridPos": { "x": 16, "y": 1, "w": 4, "h": 4 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        {
+          "expr": "sum(rate(cflog_loki_push_total{status=\"error\"}[5m]))",
+          "legendFormat": "errors/s"
+        }
+      ],
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "textMode": "value",
+        "reduceOptions": { "calcs": ["lastNotNull"] }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps",
+          "noValue": "0",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 0.01 },
+              { "color": "red", "value": 0.1 }
+            ]
+          }
+        }
+      }
+    },
+    {
+      "type": "timeseries",
+      "id": 7,
+      "title": "CF API Poll Duration",
+      "description": "How long each Cloudflare API query takes",
+      "gridPos": { "x": 0, "y": 5, "w": 8, "h": 6 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.99, sum by (le, dataset, zone) (rate(cflog_poll_duration_seconds_bucket{zone=~\"$zone\"}[5m])))",
+          "legendFormat": "p99 {{dataset}} ({{zone}})"
+        },
+        {
+          "expr": "histogram_quantile(0.50, sum by (le, dataset, zone) (rate(cflog_poll_duration_seconds_bucket{zone=~\"$zone\"}[5m])))",
+          "legendFormat": "p50 {{dataset}} ({{zone}})"
+        }
+      ],
+      "options": {
+        "legend": { "displayMode": "list", "placement": "bottom" },
+        "tooltip": { "mode": "multi" }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 2,
+            "fillOpacity": 10
+          }
+        }
+      }
+    },
+    {
+      "type": "timeseries",
+      "id": 8,
+      "title": "Loki Push Rate",
+      "description": "Rate of log pushes from the collector to Loki",
+      "gridPos": { "x": 8, "y": 5, "w": 8, "h": 6 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        {
+          "expr": "sum by (status) (rate(cflog_loki_push_total[5m]))",
+          "legendFormat": "{{status}}"
+        }
+      ],
+      "options": {
+        "legend": { "displayMode": "list", "placement": "bottom" },
+        "tooltip": { "mode": "multi" }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps",
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 2,
+            "fillOpacity": 20
+          }
+        },
+        "overrides": [
+          {
+            "matcher": { "id": "byName", "options": "error" },
+            "properties": [
+              { "id": "color", "value": { "fixedColor": "red", "mode": "fixed" } }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "type": "timeseries",
+      "id": 9,
+      "title": "Loki Push Duration",
+      "description": "How long each push to Loki takes",
+      "gridPos": { "x": 16, "y": 5, "w": 8, "h": 6 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.99, sum by (le) (rate(cflog_loki_push_duration_seconds_bucket[5m])))",
+          "legendFormat": "p99"
+        },
+        {
+          "expr": "histogram_quantile(0.50, sum by (le) (rate(cflog_loki_push_duration_seconds_bucket[5m])))",
+          "legendFormat": "p50"
+        }
+      ],
+      "options": {
+        "legend": { "displayMode": "list", "placement": "bottom" },
+        "tooltip": { "mode": "multi" }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 2,
+            "fillOpacity": 10
+          }
+        }
+      }
+    },
+    {
+      "type": "row",
+      "id": 10,
+      "title": "Web Traffic (from Cloudflare)",
+      "gridPos": { "x": 0, "y": 11, "w": 24, "h": 1 },
+      "collapsed": false
+    },
+    {
+      "type": "timeseries",
+      "id": 11,
+      "title": "Requests by Domain",
+      "description": "Total HTTP requests per domain from Cloudflare analytics",
+      "gridPos": { "x": 0, "y": 12, "w": 8, "h": 8 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        {
+          "expr": "sum by (zone) (cflog_http_requests{zone=~\"$zone\"})",
+          "legendFormat": "{{zone}}"
+        }
+      ],
+      "options": {
+        "legend": { "displayMode": "list", "placement": "bottom" },
+        "tooltip": { "mode": "multi" }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "bars",
+            "fillOpacity": 80,
+            "stacking": { "mode": "normal" }
+          }
+        }
+      }
+    },
+    {
+      "type": "timeseries",
+      "id": 12,
+      "title": "Requests by Method",
+      "description": "HTTP methods (GET, POST, etc.) across selected domains",
+      "gridPos": { "x": 8, "y": 12, "w": 8, "h": 8 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        {
+          "expr": "sum by (method) (cflog_http_requests{zone=~\"$zone\"})",
+          "legendFormat": "{{method}}"
+        }
+      ],
+      "options": {
+        "legend": { "displayMode": "list", "placement": "bottom" },
+        "tooltip": { "mode": "multi" }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "bars",
+            "fillOpacity": 80,
+            "stacking": { "mode": "normal" }
+          }
+        }
+      }
+    },
+    {
+      "type": "timeseries",
+      "id": 13,
+      "title": "Requests by Status Code",
+      "description": "HTTP response status codes across selected domains",
+      "gridPos": { "x": 16, "y": 12, "w": 8, "h": 8 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        {
+          "expr": "sum by (status) (cflog_http_requests{zone=~\"$zone\"})",
+          "legendFormat": "{{status}}"
+        }
+      ],
+      "options": {
+        "legend": { "displayMode": "list", "placement": "bottom" },
+        "tooltip": { "mode": "multi" }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "bars",
+            "fillOpacity": 80,
+            "stacking": { "mode": "normal" }
+          }
+        }
+      }
+    },
+    {
+      "type": "timeseries",
+      "id": 14,
+      "title": "Bandwidth by Domain",
+      "description": "Edge response bytes served per domain",
+      "gridPos": { "x": 0, "y": 20, "w": 8, "h": 8 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        {
+          "expr": "sum by (zone) (cflog_http_bytes{type=\"edge\", zone=~\"$zone\"})",
+          "legendFormat": "{{zone}}"
+        }
+      ],
+      "options": {
+        "legend": { "displayMode": "list", "placement": "bottom" },
+        "tooltip": { "mode": "single" }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "decbytes",
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 20,
+            "lineWidth": 2,
+            "gradientMode": "opacity"
+          }
+        }
+      }
+    },
+    {
+      "type": "table",
+      "id": 15,
+      "title": "Visitor Countries by Domain (Top 10)",
+      "description": "Where web traffic is coming from, broken out per domain",
+      "gridPos": { "x": 8, "y": 20, "w": 8, "h": 8 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        {
+          "expr": "topk(10, sum by (country, zone) (cflog_http_requests{zone=~\"$zone\"}))",
+          "legendFormat": "",
+          "instant": true,
+          "format": "table"
+        }
+      ],
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": { "Time": true, "__name__": true },
+            "renameByName": {
+              "zone": "Domain",
+              "country": "Country",
+              "Value": "Requests"
+            },
+            "indexByName": { "zone": 0, "country": 1, "Value": 2 }
+          }
+        },
+        {
+          "id": "sortBy",
+          "options": {
+            "fields": {},
+            "sort": [{ "field": "Requests", "desc": true }]
+          }
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": [
+          {
+            "matcher": { "id": "byName", "options": "Requests" },
+            "properties": [
+              { "id": "custom.cellOptions", "value": { "type": "color-background" } },
+              {
+                "id": "thresholds",
+                "value": {
+                  "mode": "absolute",
+                  "steps": [
+                    { "color": "transparent", "value": null },
+                    { "color": "super-light-blue", "value": 5 },
+                    { "color": "blue", "value": 50 },
+                    { "color": "purple", "value": 500 }
+                  ]
+                }
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "type": "table",
+      "id": 16,
+      "title": "Traffic Detail",
+      "description": "Per-method, status, country breakdown of web traffic",
+      "gridPos": { "x": 16, "y": 20, "w": 8, "h": 8 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        {
+          "expr": "sum by (method, status, country) (cflog_http_requests{zone=~\"$zone\"}) > 0",
+          "legendFormat": "",
+          "instant": true,
+          "format": "table"
+        }
+      ],
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": { "Time": true, "__name__": true },
+            "renameByName": {
+              "method": "Method",
+              "status": "Status",
+              "country": "Country",
+              "Value": "Requests"
+            }
+          }
+        },
+        {
+          "id": "sortBy",
+          "options": {
+            "fields": {},
+            "sort": [{ "field": "Requests", "desc": true }]
+          }
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": [
+          {
+            "matcher": { "id": "byName", "options": "Requests" },
+            "properties": [
+              { "id": "custom.cellOptions", "value": { "type": "color-background" } },
+              {
+                "id": "thresholds",
+                "value": {
+                  "mode": "absolute",
+                  "steps": [
+                    { "color": "transparent", "value": null },
+                    { "color": "blue", "value": 10 },
+                    { "color": "purple", "value": 100 }
+                  ]
+                }
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "type": "row",
+      "id": 20,
+      "title": "Firewall Events (from Cloudflare)",
+      "gridPos": { "x": 0, "y": 28, "w": 24, "h": 1 },
+      "collapsed": false
+    },
+    {
+      "type": "timeseries",
+      "id": 21,
+      "title": "WAF Actions Over Time",
+      "description": "Firewall actions (block, challenge, etc.) detected by Cloudflare",
+      "gridPos": { "x": 0, "y": 29, "w": 12, "h": 8 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        {
+          "expr": "sum by (action) (rate(cflog_firewall_events_total{zone=~\"$zone\"}[5m]))",
+          "legendFormat": "{{action}}"
+        }
+      ],
+      "options": {
+        "legend": { "displayMode": "list", "placement": "bottom" },
+        "tooltip": { "mode": "multi" }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "cps",
+          "custom": {
+            "drawStyle": "bars",
+            "fillOpacity": 80,
+            "stacking": { "mode": "normal" }
+          }
+        }
+      }
+    },
+    {
+      "type": "stat",
+      "id": 22,
+      "title": "Total WAF Events",
+      "description": "All-time firewall events since last restart",
+      "gridPos": { "x": 12, "y": 29, "w": 6, "h": 4 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        {
+          "expr": "sum by (zone) (cflog_firewall_events_total{zone=~\"$zone\"})",
+          "legendFormat": "{{zone}}"
+        }
+      ],
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "textMode": "value_and_name",
+        "reduceOptions": { "calcs": ["lastNotNull"] }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [{ "color": "orange", "value": null }]
+          }
+        }
+      }
+    },
+    {
+      "type": "stat",
+      "id": 23,
+      "title": "WAF Actions Breakdown",
+      "description": "Firewall events grouped by action type",
+      "gridPos": { "x": 18, "y": 29, "w": 6, "h": 4 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        {
+          "expr": "sum by (action) (cflog_firewall_events_total{zone=~\"$zone\"})",
+          "legendFormat": "{{action}}"
+        }
+      ],
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "textMode": "value_and_name",
+        "reduceOptions": { "calcs": ["lastNotNull"] }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "super-light-orange", "value": null }
+            ]
+          }
+        }
+      }
+    },
+    {
+      "type": "logs",
+      "id": 24,
+      "title": "Recent Firewall Events (from Loki)",
+      "description": "Individual WAF events as shipped to Loki by the collector",
+      "gridPos": { "x": 12, "y": 33, "w": 12, "h": 4 },
+      "datasource": { "type": "loki", "uid": "loki" },
+      "targets": [
+        {
+          "expr": "{job=\"cloudflare\", type=\"firewall\", zone=~\"$zone\"} | json",
+          "legendFormat": ""
+        }
+      ],
+      "options": {
+        "showTime": true,
+        "showLabels": true,
+        "showCommonLabels": false,
+        "wrapLogMessage": false,
+        "prettifyLogMessage": true,
+        "enableLogDetails": true,
+        "sortOrder": "Descending",
+        "dedupStrategy": "none"
+      }
+    },
+    {
+      "type": "row",
+      "id": 30,
+      "title": "Audit Logs (from Cloudflare)",
+      "gridPos": { "x": 0, "y": 37, "w": 24, "h": 1 },
+      "collapsed": false
+    },
+    {
+      "type": "timeseries",
+      "id": 31,
+      "title": "Audit Actions Over Time",
+      "description": "Account audit log actions over time, by action type",
+      "gridPos": { "x": 0, "y": 38, "w": 12, "h": 8 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        {
+          "expr": "sum by (action) (rate(cflog_audit_events_total{account=~\"$account\"}[5m]))",
+          "legendFormat": "{{action}}"
+        }
+      ],
+      "options": {
+        "legend": { "displayMode": "list", "placement": "bottom" },
+        "tooltip": { "mode": "multi" }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "cps",
+          "custom": {
+            "drawStyle": "bars",
+            "fillOpacity": 80,
+            "stacking": { "mode": "normal" }
+          }
+        }
+      }
+    },
+    {
+      "type": "stat",
+      "id": 32,
+      "title": "Total Audit Events",
+      "description": "All-time audit events since last restart",
+      "gridPos": { "x": 12, "y": 38, "w": 6, "h": 4 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        {
+          "expr": "sum by (account) (cflog_audit_events_total{account=~\"$account\"})",
+          "legendFormat": "{{account}}"
+        }
+      ],
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "textMode": "value_and_name",
+        "reduceOptions": { "calcs": ["lastNotNull"] }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [{ "color": "purple", "value": null }]
+          }
+        }
+      }
+    },
+    {
+      "type": "stat",
+      "id": 33,
+      "title": "Audit Actions Breakdown",
+      "description": "Audit events grouped by action type",
+      "gridPos": { "x": 18, "y": 38, "w": 6, "h": 4 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        {
+          "expr": "sum by (action) (cflog_audit_events_total{account=~\"$account\"})",
+          "legendFormat": "{{action}}"
+        }
+      ],
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "textMode": "value_and_name",
+        "reduceOptions": { "calcs": ["lastNotNull"] }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "semi-dark-purple", "value": null }
+            ]
+          }
+        }
+      }
+    },
+    {
+      "type": "logs",
+      "id": 34,
+      "title": "Recent Audit Events (from Loki)",
+      "description": "Individual account audit events as shipped to Loki by the collector",
+      "gridPos": { "x": 12, "y": 42, "w": 12, "h": 4 },
+      "datasource": { "type": "loki", "uid": "loki" },
+      "targets": [
+        {
+          "expr": "{job=\"cloudflare\", type=\"audit\", account=~\"$account\"} | json",
+          "legendFormat": ""
+        }
+      ],
+      "options": {
+        "showTime": true,
+        "showLabels": true,
+        "showCommonLabels": false,
+        "wrapLogMessage": false,
+        "prettifyLogMessage": true,
+        "enableLogDetails": true,
+        "sortOrder": "Descending",
+        "dedupStrategy": "none"
+      }
+    },
+    {
+      "type": "row",
+      "id": 40,
+      "title": "Collector Logs",
+      "gridPos": { "x": 0, "y": 46, "w": 24, "h": 1 },
+      "collapsed": false
+    },
+    {
+      "type": "logs",
+      "id": 41,
+      "title": "Service Logs (collector process)",
+      "description": "Stdout from the collector itself — poll results, errors, startup info. Click trace IDs to jump to Tempo.",
+      "gridPos": { "x": 0, "y": 47, "w": 24, "h": 10 },
+      "datasource": { "type": "loki", "uid": "loki" },
+      "targets": [
+        {
+          "expr": "{job=\"nomad\", task=\"cloudflare-log-collector\"} | json",
+          "legendFormat": ""
+        }
+      ],
+      "options": {
+        "showTime": true,
+        "showLabels": false,
+        "showCommonLabels": false,
+        "wrapLogMessage": false,
+        "prettifyLogMessage": true,
+        "enableLogDetails": true,
+        "sortOrder": "Descending",
+        "dedupStrategy": "none"
+      }
+    },
+    {
+      "type": "logs",
+      "id": 42,
+      "title": "HTTP Traffic Logs (raw Cloudflare data in Loki)",
+      "description": "The raw HTTP traffic data points that the collector shipped to Loki from Cloudflare analytics",
+      "gridPos": { "x": 0, "y": 57, "w": 24, "h": 8 },
+      "datasource": { "type": "loki", "uid": "loki" },
+      "targets": [
+        {
+          "expr": "{job=\"cloudflare\", type=\"http_traffic\", zone=~\"$zone\"} | json",
+          "legendFormat": ""
+        }
+      ],
+      "options": {
+        "showTime": true,
+        "showLabels": true,
+        "showCommonLabels": false,
+        "wrapLogMessage": false,
+        "prettifyLogMessage": true,
+        "enableLogDetails": true,
+        "sortOrder": "Descending",
+        "dedupStrategy": "none"
+      }
+    }
+  ],
+  "templating": {
+    "list": [
+      {
+        "name": "zone",
+        "label": "Domain",
+        "type": "query",
+        "datasource": { "type": "prometheus", "uid": "prometheus" },
+        "query": "label_values(cflog_poll_total, zone)",
+        "includeAll": true,
+        "allValue": ".*",
+        "current": { "text": "All", "value": "$__all" },
+        "multi": true,
+        "refresh": 2,
+        "sort": 1
+      },
+      {
+        "name": "account",
+        "label": "Account",
+        "type": "query",
+        "datasource": { "type": "prometheus", "uid": "prometheus" },
+        "query": "label_values(cflog_audit_events_total, account)",
+        "includeAll": true,
+        "allValue": ".*",
+        "current": { "text": "All", "value": "$__all" },
+        "multi": true,
+        "refresh": 2,
+        "sort": 1
+      }
+    ]
+  },
+  "annotations": { "list": [] }
 }

--- a/infrastructure/terragrunt/_env_helpers/vault-config.hcl
+++ b/infrastructure/terragrunt/_env_helpers/vault-config.hcl
@@ -152,6 +152,7 @@ inputs = {
     "cloudflared",
     "cloudflare",
     "cloudflare-wandns",
+    "cloudflare-logcollector",
     "aptly-admin",
     "vaultwarden",
     "temporal",

--- a/infrastructure/terragrunt/_env_helpers/vault-secrets.hcl
+++ b/infrastructure/terragrunt/_env_helpers/vault-secrets.hcl
@@ -19,7 +19,10 @@ dependency "cloudflare_tokens" {
   config_path = "${get_repo_root()}/infrastructure/terragrunt/global/cloudflare-tokens"
 
   mock_outputs = {
-    vault_data = { wandns = { api_token = "mock-wandns-token" } }
+    vault_data = {
+      wandns       = { api_token = "mock-wandns-token" }
+      logcollector = { api_token = "mock-logcollector-token" }
+    }
   }
   mock_outputs_allowed_terraform_commands = ["init", "plan", "validate"]
 }

--- a/infrastructure/terragrunt/root.hcl
+++ b/infrastructure/terragrunt/root.hcl
@@ -241,6 +241,23 @@ locals {
         resources         = { "com.cloudflare.api.account.zone.${local.cloudflare_munchbox_zone_id}" = "*" }
       }]
     }
+    # --- cloudflare-log-collector: audit logs + per-zone analytics, read-only ---
+    # Single policy on purpose: the cloudflare v5 provider can't round-trip a token with
+    # multiple policies ("inconsistent result after apply"). One policy is fine even with
+    # mixed scopes - each permission group only applies to its matching resource type:
+    # Account Settings Read -> the account resource (audit logs); Analytics Read -> the
+    # zone resources (per-zone GraphQL firewall/http analytics).
+    logcollector = {
+      name = "munchbox-logcollector-audit-analytics"
+      policies = [{
+        permission_groups = ["Analytics Read", "Account Settings Read"]
+        resources = {
+          "com.cloudflare.api.account.${local.cloudflare_account_id}"               = "*"
+          "com.cloudflare.api.account.zone.${local.cloudflare_munchbox_zone_id}"    = "*"
+          "com.cloudflare.api.account.zone.${local.cloudflare_alexfreidah_zone_id}" = "*"
+        }
+      }]
+    }
   }
 
   # --- generated secrets written to Vault by global/vault-secrets ---
@@ -255,6 +272,10 @@ locals {
       source = "cloudflare_tokens"
       key    = "wandns"
       static = { zone_id = local.cloudflare_munchbox_zone_id }
+    }
+    "cloudflare-logcollector" = {
+      source = "cloudflare_tokens"
+      key    = "logcollector"
     }
   }
 
@@ -374,6 +395,26 @@ locals {
       task_queue    = "cleanup-task-queue"
       workflow_id   = "registry-gc-scheduled"
       input         = { job_name = "registry", registry_data_dir = "/mnt/gdrive/munchbox-data/registry", registry_image = "registry:3", dry_run = false, delete_untagged = true }
+    }
+    "aptly-cleanup-weekly" = {
+      schedule_id   = "aptly-cleanup-weekly"
+      year          = "*"
+      hour          = "4"
+      day_of_week   = "0"
+      workflow_type = "AptlyCleanup"
+      task_queue    = "cleanup-task-queue"
+      workflow_id   = "aptly-cleanup-scheduled"
+      input         = { job_name = "aptly", image = "urpylka/aptly:1.6.2" }
+    }
+    "postgres-maintenance-weekly" = {
+      schedule_id   = "postgres-maintenance-weekly"
+      year          = "*"
+      hour          = "6"
+      day_of_week   = "0"
+      workflow_type = "PostgresMaintenance"
+      task_queue    = "cleanup-task-queue"
+      workflow_id   = "postgres-maintenance-scheduled"
+      input         = { concurrency = 2 }
     }
   }
 

--- a/nomad/jobs/infrastructure/temporal/README.md
+++ b/nomad/jobs/infrastructure/temporal/README.md
@@ -5,7 +5,7 @@ scanning. The server exposes a gRPC API on 7233; the UI is a separate job.
 
 ## Image
 
-- temporal-server: `temporalio/server:1.29.1`
+- temporal-server: `temporalio/server:1.31.0`
 - temporal-ui: `temporalio/ui:2.50.0`
 
 ## Hostname / exposure

--- a/nomad/jobs/infrastructure/temporal/files/dynamicconfig.yaml
+++ b/nomad/jobs/infrastructure/temporal/files/dynamicconfig.yaml
@@ -1,0 +1,4 @@
+# Temporal dynamic config - intentionally empty (use built-in defaults).
+# Temporal 1.30+ removed the empty docker.yaml that 1.29 shipped in-image but
+# still requires the file to exist, so the pack mounts this at
+# /etc/temporal/config/dynamicconfig/docker.yaml.

--- a/nomad/jobs/infrastructure/temporal/temporal-schema.nomad.hcl
+++ b/nomad/jobs/infrastructure/temporal/temporal-schema.nomad.hcl
@@ -1,0 +1,90 @@
+# -------------------------------------------------------------------------------
+# Temporal Schema Migration - one-shot batch job
+#
+# Project: Munchbox / Author: Alex Freidah
+#
+# Runs temporal-sql-tool update-schema against the Patroni/Postgres backend
+# (reached via the haproxy-postgres Consul DNS name, TLS with the Vault PKI CA)
+# for both the `temporal` and `temporal_visibility` databases.
+#
+# Temporal only supports sequential minor upgrades, so the flow is:
+#   1. set the admin-tools image tag below to the NEXT server minor
+#   2. run this job (make run JOB=temporal-schema) and confirm it completes
+#   3. bump temporal-server.hcl to the same version and deploy it
+#   4. repeat for the following minor
+# The image tag here == the schema version being migrated TO.
+# -------------------------------------------------------------------------------
+
+job "temporal-schema" {
+  datacenters = ["munchbox"]
+  type        = "batch"
+
+  group "migrate" {
+    count = 1
+
+    # --- one-shot: surface failures, don't loop ---
+    restart {
+      attempts = 0
+      mode     = "fail"
+    }
+    reschedule {
+      attempts  = 0
+      unlimited = false
+    }
+
+    task "update-schema" {
+      driver = "docker"
+
+      vault {
+        role = "nomad-workloads"
+      }
+
+      identity {
+        env  = true
+        file = true
+        aud  = ["vault.io"]
+      }
+
+      config {
+        image        = "temporalio/admin-tools:1.31.0"
+        network_mode = "host"
+        command      = "sh"
+        args = ["-c",
+          "set -eu; temporal-sql-tool --db temporal update-schema -d /etc/temporal/schema/postgresql/v12/temporal/versioned && temporal-sql-tool --db temporal_visibility update-schema -d /etc/temporal/schema/postgresql/v12/visibility/versioned"
+        ]
+      }
+
+      # --- Postgres TLS CA (Vault PKI), same source as the server's ca.crt ---
+      template {
+        destination = "secrets/ca.crt"
+        data        = <<EOF
+{{ with secret "pki_int/cert/ca" }}{{ .Data.certificate }}{{ end }}
+{{ with secret "pki/cert/ca" }}{{ .Data.certificate }}{{ end }}
+EOF
+      }
+
+      # --- temporal-sql-tool connection settings (env-var form of the CLI flags) ---
+      template {
+        destination = "secrets/migrate.env"
+        env         = true
+        data        = <<EOF
+{{ with secret "secret/data/temporal" -}}
+SQL_PLUGIN=postgres12_pgx
+SQL_HOST=haproxy-postgres.service.consul
+SQL_PORT=5433
+SQL_USER={{ .Data.data.db_username }}
+SQL_PASSWORD={{ .Data.data.db_password }}
+SQL_TLS=true
+SQL_TLS_CA_FILE=/secrets/ca.crt
+SQL_TLS_DISABLE_HOST_VERIFICATION=true
+{{- end }}
+EOF
+      }
+
+      resources {
+        cpu    = 200
+        memory = 128
+      }
+    }
+  }
+}

--- a/nomad/jobs/infrastructure/temporal/temporal-server.hcl
+++ b/nomad/jobs/infrastructure/temporal/temporal-server.hcl
@@ -14,7 +14,7 @@ job_dir = "/home/afreidah/tools/munchbox/nomad/jobs/infrastructure/temporal"
 # --- General Settings ---
 name  = "temporal-server"
 type  = "service"
-image = "temporalio/server:1.29.1"
+image = "temporalio/server:1.31.0"
 port  = 7233
 static_port = 7233
 host_network = true
@@ -38,7 +38,9 @@ vault = true
 # --- Templates (inject secrets from Vault as env vars) ---
 templates = [
   { src = "temporal-env.tpl", dest = "/secrets/temporal.env", env = true, vault = true },
-  { src = "ca.crt.tpl", dest = "/secrets/ca.crt", vault = true }
+  { src = "ca.crt.tpl", dest = "/secrets/ca.crt", vault = true },
+  # --- 1.30+ requires the dynamic-config file to exist (1.29 shipped an empty one in-image) ---
+  { src = "dynamicconfig.yaml", dest = "/etc/temporal/config/dynamicconfig/docker.yaml" }
 ]
 
 # --- Traefik integration ---

--- a/nomad/jobs/monitoring/cloudflare-log-collector/cloudflare-log-collector.nomad.hcl
+++ b/nomad/jobs/monitoring/cloudflare-log-collector/cloudflare-log-collector.nomad.hcl
@@ -4,9 +4,10 @@
 # Project: Munchbox / Author: Alex Freidah
 #
 # Polls the Cloudflare GraphQL Analytics API for firewall events and HTTP
-# traffic statistics. Ships firewall events to Loki as structured JSON logs
-# and exposes HTTP traffic metrics via Prometheus. Traces poll cycles with
-# OpenTelemetry for Tempo correlation.
+# traffic statistics and the REST Audit Logs API for account audit events. Ships
+# firewall and audit events to Loki as structured JSON logs and exposes HTTP
+# traffic metrics via Prometheus. Traces poll cycles with OpenTelemetry for Tempo
+# correlation.
 # -------------------------------------------------------------------------------
 
 job "cloudflare-log-collector" {
@@ -114,7 +115,7 @@ job "cloudflare-log-collector" {
 
       # --- Docker Configuration ---
       config {
-        image              = "registry.munchbox.cc/cloudflare-log-collector:v0.1.12"
+        image              = "registry.munchbox.cc/cloudflare-log-collector:v0.1.16-5-g2b402ee"
         image_pull_timeout = "5m"
         network_mode       = "host"
         args               = ["-config", "/secrets/config.yaml"]
@@ -129,12 +130,17 @@ job "cloudflare-log-collector" {
         change_mode = "restart"
         data        = <<-EOF
 cloudflare:
-  api_token: "{{ with secret "secret/data/cloudflare" }}{{ .Data.data.api_token }}{{ end }}"
+  api_token: "{{ with secret "secret/data/cloudflare-logcollector" }}{{ .Data.data.api_token }}{{ end }}"
   zones:
     - id: "bd3f7236466255155ab59b9d21cd88fd"
       name: "munchbox.cc"
     - id: "79e647e591f69cc27254bf4771464619"
       name: "alexfreidah.com"
+  audit_logs:
+    enabled: true
+    accounts:
+      - id: "02e53aa2113dc76e57f9598af2f74939"
+        name: "munchbox"
   poll_interval: 1m
   backfill_window: 1h
 

--- a/nomad/jobs/temporal-workflows/cleanup-worker/README.md
+++ b/nomad/jobs/temporal-workflows/cleanup-worker/README.md
@@ -6,7 +6,7 @@ schedule by a Temporal Schedule.
 
 ## Image
 
-`registry.munchbox.cc/cleanup-worker:v0.2.4`
+`registry.munchbox.cc/cleanup-worker:v0.2.7`
 
 ## Hostname / exposure
 

--- a/nomad/jobs/temporal-workflows/cleanup-worker/cleanup-worker.nomad.hcl
+++ b/nomad/jobs/temporal-workflows/cleanup-worker/cleanup-worker.nomad.hcl
@@ -110,7 +110,7 @@ job "cleanup-worker" {
       }
 
       config {
-        image              = "registry.munchbox.cc/cleanup-worker:v0.2.4"
+        image              = "registry.munchbox.cc/cleanup-worker:v0.2.7"
         image_pull_timeout = "5m"
         network_mode       = "host"
         ports              = ["metrics"]

--- a/nomad/jobs/temporal-workflows/trivy-scan-worker/README.md
+++ b/nomad/jobs/temporal-workflows/trivy-scan-worker/README.md
@@ -7,7 +7,7 @@ that the trivy-dashboard reads from. Listens on the
 
 ## Image
 
-`registry.munchbox.cc/trivy-scan-worker:v0.2.0`
+`registry.munchbox.cc/trivy-scan-worker:v0.2.1`
 
 ## Hostname / exposure
 

--- a/nomad/jobs/temporal-workflows/trivy-scan-worker/trivy-scan-worker.nomad.hcl
+++ b/nomad/jobs/temporal-workflows/trivy-scan-worker/trivy-scan-worker.nomad.hcl
@@ -109,7 +109,7 @@ job "trivy-scan-worker" {
       }
 
       config {
-        image              = "registry.munchbox.cc/trivy-scan-worker:v0.2.0"
+        image              = "registry.munchbox.cc/trivy-scan-worker:v0.2.1"
         image_pull_timeout = "10m"
         network_mode       = "host"
         ports              = ["metrics"]


### PR DESCRIPTION
Munchbox side of the cleanup-worker maintenance work (worker code in afreidah/nomad-temporal-jobs#37).

- **terragrunt schedules** — `aptly-cleanup-weekly` (Sun 4 AM) and `postgres-maintenance-weekly` (Sun 6 AM) on `cleanup-task-queue`.
- **cleanup-worker job** — Postgres creds (`PGPASSWORD` from `secret/data/postgres-shared/root`, `PG_HOST`/`PG_USER`/`PG_SSLMODE`) + image `v0.2.7`.
- **trivy-scan-worker job** — image `v0.2.1` (shared Postgres client refactor).
- Submodule pointer bumped to the maintenance-workflows commit.

Also folds in in-flight infra config that was uncommitted in the tree (cloudflare log-collector token/secret + job, temporal-server config/schema/dynamicconfig) per "commit everything uncommitted."

⚠️ Branch name is stale (reused the merged container-image-upgrades branch); content is the temporal maintenance work above.