### PR TITLE
terragrunt: codify Jellyfin config (encoding, Live TV, guide-refresh)

### DIFF
--- a/infrastructure/terragrunt/_env_helpers/jellyfin-config.hcl
+++ b/infrastructure/terragrunt/_env_helpers/jellyfin-config.hcl
@@ -1,0 +1,35 @@
+# -----------------------------------------------------------------------------
+# JELLYFIN-CONFIG ENV HELPER
+# -----------------------------------------------------------------------------
+#
+# Composition for the jellyfin-config module. The provider endpoint + api_key
+# come from Vault (secret/jellyfin) via TF_VAR_* exported by munchbox-env.sh;
+# the singleton configs and scheduled tasks come from root.hcl. Configs default
+# to null (unmanaged) so a fresh apply is a no-op until real values are codified.
+#
+# Author: Alex Freidah / Project: Munchbox
+# -----------------------------------------------------------------------------
+
+terraform {
+  source = "${get_repo_root()}/infrastructure/terragrunt/modules//jellyfin-config"
+}
+
+locals {
+  root = read_terragrunt_config(find_in_parent_folders("root.hcl"))
+}
+
+inputs = {
+  # --- take the URL token only; the Vault value may carry a trailing note ---
+  jellyfin_endpoint = trimspace(split(" ", get_env("TF_VAR_jellyfin_endpoint", ""))[0])
+  jellyfin_api_key  = get_env("TF_VAR_jellyfin_api_key", "")
+
+  # --- json-encode each settings object here; null passes through untouched ---
+  encoding_configuration_json = local.root.locals.jellyfin_encoding_configuration == null ? null : jsonencode(local.root.locals.jellyfin_encoding_configuration)
+  livetv_configuration_json   = local.root.locals.jellyfin_livetv_configuration == null ? null : jsonencode(local.root.locals.jellyfin_livetv_configuration)
+  system_configuration_json   = local.root.locals.jellyfin_system_configuration == null ? null : jsonencode(local.root.locals.jellyfin_system_configuration)
+
+  scheduled_tasks = {
+    for k, t in local.root.locals.jellyfin_scheduled_tasks :
+    k => { task_id = t.task_id, triggers_json = jsonencode(t.triggers) }
+  }
+}

--- a/infrastructure/terragrunt/global/app-config/jellyfin-config/.terraform.lock.hcl
+++ b/infrastructure/terragrunt/global/app-config/jellyfin-config/.terraform.lock.hcl
@@ -1,0 +1,24 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/thephaseless/jellyfin" {
+  version     = "0.1.0"
+  constraints = "~> 0.1"
+  hashes = [
+    "h1:+hltAobwC2t8v6xYXsO4Lx1JvY02d+J/r9lmP/BWJsA=",
+    "zh:07da8e0ed645024368b84a07ca2992ff925d55bb42770bc214b6d31109125322",
+    "zh:202c50fcaa403c42a8aad2db268b7757ccd6490ea6604df1daa2f5ef532d9c6d",
+    "zh:3c058b5884e49ff7d83ddbac12835438b6f16da31c4b5b68bd7d16f86173037c",
+    "zh:62007d0dc1c4b5bae4fea5b9a21a3e8ca3f8b0db03d17f09b6cc2286e8cca683",
+    "zh:6fc89172ad51c99bb76b22ffbdcc33035283b8b5f6aae6e48052a01aacc6f8cc",
+    "zh:7a92ac0bcd81c0a1be70680d75757267220fe0131e902e8c0c9154a4f5ebd47c",
+    "zh:8799ed6ba41386a169a659843fc3f27191df08bee94be2ca489bbde5bb7fcf9d",
+    "zh:87a6684804170c84a34135f6bea92d39d7c2be4d6e9e3d10183e8e1e27a285c6",
+    "zh:890df766e9b839623b1f0437355032a3c006226a6c200cd911e15ee1a9014e9f",
+    "zh:96b3e05664c9fd805e6baa7628bbf44791186058d007c406a2721b1410db4503",
+    "zh:990e15b69092ae37347dbebe76d14520b2db519797ea39b3bc1eded8ab4fc422",
+    "zh:a2b9b765f7e9bae7cd48cd9569761e8ad47a6b57b4d6a68e0328bf1e3d76f58a",
+    "zh:e9227c16dc3d9d5f9e236f5c9c56910e4603eb1e1ea8cc32c18fc43d483734cf",
+    "zh:e93e27cd2333b07bd01b15f993397231c1d47f59547286231c565db1cd72a25d",
+  ]
+}

--- a/infrastructure/terragrunt/global/app-config/jellyfin-config/terragrunt.hcl
+++ b/infrastructure/terragrunt/global/app-config/jellyfin-config/terragrunt.hcl
@@ -1,0 +1,12 @@
+# -----------------------------------------------------------------------------
+# JELLYFIN CONFIG LEAF
+# -----------------------------------------------------------------------------
+
+include "root" {
+  path = find_in_parent_folders("root.hcl")
+}
+
+include "jellyfin-config" {
+  path   = "${get_repo_root()}/infrastructure/terragrunt/_env_helpers/jellyfin-config.hcl"
+  expose = true
+}

--- a/infrastructure/terragrunt/modules/jellyfin-config/.terraform.lock.hcl
+++ b/infrastructure/terragrunt/modules/jellyfin-config/.terraform.lock.hcl
@@ -1,0 +1,24 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/thephaseless/jellyfin" {
+  version     = "0.1.0"
+  constraints = "~> 0.1"
+  hashes = [
+    "h1:+hltAobwC2t8v6xYXsO4Lx1JvY02d+J/r9lmP/BWJsA=",
+    "zh:07da8e0ed645024368b84a07ca2992ff925d55bb42770bc214b6d31109125322",
+    "zh:202c50fcaa403c42a8aad2db268b7757ccd6490ea6604df1daa2f5ef532d9c6d",
+    "zh:3c058b5884e49ff7d83ddbac12835438b6f16da31c4b5b68bd7d16f86173037c",
+    "zh:62007d0dc1c4b5bae4fea5b9a21a3e8ca3f8b0db03d17f09b6cc2286e8cca683",
+    "zh:6fc89172ad51c99bb76b22ffbdcc33035283b8b5f6aae6e48052a01aacc6f8cc",
+    "zh:7a92ac0bcd81c0a1be70680d75757267220fe0131e902e8c0c9154a4f5ebd47c",
+    "zh:8799ed6ba41386a169a659843fc3f27191df08bee94be2ca489bbde5bb7fcf9d",
+    "zh:87a6684804170c84a34135f6bea92d39d7c2be4d6e9e3d10183e8e1e27a285c6",
+    "zh:890df766e9b839623b1f0437355032a3c006226a6c200cd911e15ee1a9014e9f",
+    "zh:96b3e05664c9fd805e6baa7628bbf44791186058d007c406a2721b1410db4503",
+    "zh:990e15b69092ae37347dbebe76d14520b2db519797ea39b3bc1eded8ab4fc422",
+    "zh:a2b9b765f7e9bae7cd48cd9569761e8ad47a6b57b4d6a68e0328bf1e3d76f58a",
+    "zh:e9227c16dc3d9d5f9e236f5c9c56910e4603eb1e1ea8cc32c18fc43d483734cf",
+    "zh:e93e27cd2333b07bd01b15f993397231c1d47f59547286231c565db1cd72a25d",
+  ]
+}

--- a/infrastructure/terragrunt/modules/jellyfin-config/Makefile
+++ b/infrastructure/terragrunt/modules/jellyfin-config/Makefile
@@ -1,0 +1,1 @@
+include ../_common.mk

--- a/infrastructure/terragrunt/modules/jellyfin-config/main.tf
+++ b/infrastructure/terragrunt/modules/jellyfin-config/main.tf
@@ -1,0 +1,52 @@
+# -----------------------------------------------------------------------------
+# JELLYFIN-CONFIG MODULE
+#
+# Project: Munchbox / Author: Alex Freidah
+#
+# Manages a self-hosted Jellyfin server's configuration: the singleton encoding,
+# Live TV, and system config blobs, plus scheduled-task triggers. Each input is
+# the provider's *_json string verbatim; the env_helper does the HCL-to-JSON
+# encoding, so the concrete jellyfin keys stay in root.hcl and this module stays
+# generic.
+# -----------------------------------------------------------------------------
+
+# -----------------------------------------------------------------------------
+# ENCODING CONFIGURATION (singleton)
+# -----------------------------------------------------------------------------
+
+resource "jellyfin_encoding_configuration" "this" {
+  count = var.encoding_configuration_json == null ? 0 : 1
+
+  configuration_json = var.encoding_configuration_json
+}
+
+# -----------------------------------------------------------------------------
+# LIVE TV CONFIGURATION (singleton)
+# -----------------------------------------------------------------------------
+
+resource "jellyfin_livetv_configuration" "this" {
+  count = var.livetv_configuration_json == null ? 0 : 1
+
+  configuration_json = var.livetv_configuration_json
+}
+
+# -----------------------------------------------------------------------------
+# SYSTEM CONFIGURATION (singleton)
+# -----------------------------------------------------------------------------
+
+resource "jellyfin_system_configuration" "this" {
+  count = var.system_configuration_json == null ? 0 : 1
+
+  configuration_json = var.system_configuration_json
+}
+
+# -----------------------------------------------------------------------------
+# SCHEDULED TASKS
+# -----------------------------------------------------------------------------
+
+resource "jellyfin_scheduled_task" "this" {
+  for_each = var.scheduled_tasks
+
+  task_id       = each.value.task_id
+  triggers_json = each.value.triggers_json
+}

--- a/infrastructure/terragrunt/modules/jellyfin-config/outputs.tf
+++ b/infrastructure/terragrunt/modules/jellyfin-config/outputs.tf
@@ -1,0 +1,17 @@
+# -----------------------------------------------------------------------------
+# JELLYFIN-CONFIG Module Outputs
+# -----------------------------------------------------------------------------
+
+output "managed_singletons" {
+  description = "Which singleton configs this module manages (true when a non-null input was supplied)."
+  value = {
+    encoding = length(jellyfin_encoding_configuration.this) > 0
+    livetv   = length(jellyfin_livetv_configuration.this) > 0
+    system   = length(jellyfin_system_configuration.this) > 0
+  }
+}
+
+output "scheduled_task_ids" {
+  description = "Map of Terraform key -> managed Jellyfin scheduled task id."
+  value       = { for k, t in jellyfin_scheduled_task.this : k => t.task_id }
+}

--- a/infrastructure/terragrunt/modules/jellyfin-config/providers.tf
+++ b/infrastructure/terragrunt/modules/jellyfin-config/providers.tf
@@ -1,0 +1,8 @@
+# -----------------------------------------------------------------------------
+# JELLYFIN-CONFIG MODULE - PROVIDER CONFIG
+# -----------------------------------------------------------------------------
+
+provider "jellyfin" {
+  endpoint = var.jellyfin_endpoint
+  api_key  = var.jellyfin_api_key
+}

--- a/infrastructure/terragrunt/modules/jellyfin-config/tests/default.tftest.hcl
+++ b/infrastructure/terragrunt/modules/jellyfin-config/tests/default.tftest.hcl
@@ -1,0 +1,129 @@
+# -----------------------------------------------------------------------------
+# jellyfin-config module tests (plan-only)
+#
+# Project: Munchbox / Author: Alex Freidah
+#
+# Asserts the singleton count-gating (a config renders one resource when its
+# JSON is set, zero when null), the configuration_json pass-through, the
+# scheduled_tasks for_each fan-out, and the all-empty edge case.
+# -----------------------------------------------------------------------------
+
+mock_provider "jellyfin" {}
+
+variables {
+  jellyfin_endpoint = "http://mock-jellyfin.test:8096"
+  jellyfin_api_key  = "mock-api-key"
+
+  encoding_configuration_json = "{\"EnableHardwareEncoding\":true,\"H264Crf\":23}"
+  livetv_configuration_json   = "{\"PrePaddingSeconds\":120,\"TunerHosts\":[],\"ListingProviders\":[]}"
+
+  scheduled_tasks = {
+    "guide-refresh" = {
+      task_id       = "a558367c153e8b2ca2b0f9d4f5f8e6c1"
+      triggers_json = "[{\"Type\":\"IntervalTrigger\",\"IntervalTicks\":432000000000}]"
+    }
+    "scan-library" = {
+      task_id       = "7738148ffcd07979c7ceb148e06b3aed"
+      triggers_json = "[{\"Type\":\"DailyTrigger\",\"TimeOfDayTicks\":0}]"
+    }
+  }
+}
+
+# -------------------------------------------------------------------------
+# Singleton configs render one resource each when their JSON is set
+# -------------------------------------------------------------------------
+
+run "singletons_managed_when_set" {
+  command = plan
+
+  # --- encoding json set -> one resource ---
+  assert {
+    condition     = length(jellyfin_encoding_configuration.this) == 1
+    error_message = "encoding_configuration_json set -> one resource"
+  }
+
+  # --- live tv json set -> one resource ---
+  assert {
+    condition     = length(jellyfin_livetv_configuration.this) == 1
+    error_message = "livetv_configuration_json set -> one resource"
+  }
+
+  # --- configuration_json passes through verbatim ---
+  assert {
+    condition     = jellyfin_encoding_configuration.this[0].configuration_json == var.encoding_configuration_json
+    error_message = "configuration_json should pass through the encoding input verbatim"
+  }
+}
+
+# -------------------------------------------------------------------------
+# scheduled_tasks for_each: one resource per task, triggers_json verbatim
+# -------------------------------------------------------------------------
+
+run "scheduled_tasks_for_each" {
+  command = plan
+
+  # --- two task inputs -> two resources ---
+  assert {
+    condition     = length(jellyfin_scheduled_task.this) == 2
+    error_message = "two scheduled_tasks -> two resources"
+  }
+
+  # --- task_id propagates from the map value ---
+  assert {
+    condition     = jellyfin_scheduled_task.this["guide-refresh"].task_id == "a558367c153e8b2ca2b0f9d4f5f8e6c1"
+    error_message = "task_id should propagate from the map value"
+  }
+
+  # --- triggers_json passes through verbatim (no number coercion) ---
+  assert {
+    condition     = jellyfin_scheduled_task.this["guide-refresh"].triggers_json == var.scheduled_tasks["guide-refresh"].triggers_json
+    error_message = "triggers_json should pass through the trigger list verbatim"
+  }
+}
+
+# -------------------------------------------------------------------------
+# Unset singletons are not managed
+# -------------------------------------------------------------------------
+
+run "singletons_skipped_when_null" {
+  command = plan
+
+  variables {
+    encoding_configuration_json = null
+    livetv_configuration_json   = null
+    system_configuration_json   = null
+  }
+
+  # --- null encoding -> zero resources ---
+  assert {
+    condition     = length(jellyfin_encoding_configuration.this) == 0
+    error_message = "null encoding_configuration_json -> zero resources"
+  }
+
+  # --- null livetv -> zero resources ---
+  assert {
+    condition     = length(jellyfin_livetv_configuration.this) == 0
+    error_message = "null livetv_configuration_json -> zero resources"
+  }
+}
+
+# -------------------------------------------------------------------------
+# Empty inputs edge case: nothing managed
+# -------------------------------------------------------------------------
+
+run "empty_inputs" {
+  command = plan
+
+  variables {
+    encoding_configuration_json = null
+    livetv_configuration_json   = null
+    system_configuration_json   = null
+    scheduled_tasks             = {}
+  }
+
+  # --- no tasks -> zero scheduled task resources ---
+  assert {
+    condition     = length(jellyfin_scheduled_task.this) == 0
+    error_message = "empty scheduled_tasks -> zero resources"
+  }
+}

--- a/infrastructure/terragrunt/modules/jellyfin-config/variables.tf
+++ b/infrastructure/terragrunt/modules/jellyfin-config/variables.tf
@@ -1,0 +1,56 @@
+# -----------------------------------------------------------------------------
+# JELLYFIN-CONFIG MODULE - VARIABLES
+# -----------------------------------------------------------------------------
+
+# -----------------------------------------------------------------------------
+# PROVIDER CONNECTION
+# -----------------------------------------------------------------------------
+
+variable "jellyfin_endpoint" {
+  description = "Jellyfin server base URL (e.g. http://host:8096); sourced from TF_VAR_jellyfin_endpoint via the env_helper."
+  type        = string
+}
+
+variable "jellyfin_api_key" {
+  description = "Jellyfin API key; sourced from TF_VAR_jellyfin_api_key via the env_helper."
+  type        = string
+  sensitive   = true
+}
+
+# -----------------------------------------------------------------------------
+# SINGLETON CONFIGURATIONS
+# -----------------------------------------------------------------------------
+# --- Each is the provider's configuration_json verbatim; the env_helper
+#     json-encodes the settings object from root.hcl (null = unmanaged). The
+#     concrete jellyfin keys live in root.hcl, not in this module. ---
+
+variable "encoding_configuration_json" {
+  description = "Encoding/transcoding settings as a JSON string for jellyfin_encoding_configuration. null = unmanaged."
+  type        = string
+  default     = null
+}
+
+variable "livetv_configuration_json" {
+  description = "Live TV settings (tuner hosts + listing providers) as a JSON string for jellyfin_livetv_configuration. null = unmanaged."
+  type        = string
+  default     = null
+}
+
+variable "system_configuration_json" {
+  description = "System settings as a JSON string for jellyfin_system_configuration. null = unmanaged."
+  type        = string
+  default     = null
+}
+
+# -----------------------------------------------------------------------------
+# SCHEDULED TASKS
+# -----------------------------------------------------------------------------
+
+variable "scheduled_tasks" {
+  description = "Map of Jellyfin scheduled tasks to manage; map key is the Terraform state key. triggers_json is the provider's triggers_json (a JSON array) verbatim."
+  type = map(object({
+    task_id       = string
+    triggers_json = string
+  }))
+  default = {}
+}

--- a/infrastructure/terragrunt/modules/jellyfin-config/versions.tf
+++ b/infrastructure/terragrunt/modules/jellyfin-config/versions.tf
@@ -1,0 +1,14 @@
+# -----------------------------------------------------------------------------
+# JELLYFIN-CONFIG Module Version Requirements
+# -----------------------------------------------------------------------------
+
+terraform {
+  required_version = ">= 1.5"
+
+  required_providers {
+    jellyfin = {
+      source  = "ThePhaseless/jellyfin"
+      version = "~> 0.1"
+    }
+  }
+}

--- a/infrastructure/terragrunt/networking/oci/.terraform.lock.hcl
+++ b/infrastructure/terragrunt/networking/oci/.terraform.lock.hcl
@@ -24,29 +24,6 @@ provider "registry.terraform.io/hashicorp/aws" {
   ]
 }
 
-provider "registry.terraform.io/hashicorp/oci" {
-  version = "8.17.0"
-  hashes = [
-    "h1:gRBkHTkhDWV9XH+dhcvQNb2JwKpM+QP3VIDe41WoADo=",
-    "zh:0d4fb4119f645f6facd09b201ca0463a50c88593bff91984e57f17e8f13090d0",
-    "zh:24c09162ae35c6f7ee28cc3907d39143968376ef050560e0452e6ecc06514630",
-    "zh:3975b2c8a36add4a961bbb0fffec6e74cf0c4051f8cd02a0de82f03920dd6e21",
-    "zh:39c6b6be9c8956bac5e6cdaa9b82519760dd68d5e0e222de91b916ff2bcb7995",
-    "zh:62d7d6f60b254a07f96766e27e39e29bea53b346e7e61f517f0cf8ede2d43dac",
-    "zh:6e4f9dbd333531a8487d49ef8747e79fd49920e13b6b8993831e6da46ff580d9",
-    "zh:6e7d4d9c12803df4d4b8484665da280baca694a9ea1ff9ccee0623a02281103f",
-    "zh:7794ed82797cc64732b84c834bc9f8dfe57fd715ab6eb7ec88d500fe2a05a6c6",
-    "zh:85f7044b30a8dad5929eee2d4c8f9131ff718cf913304aba23d21f289c9873fd",
-    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
-    "zh:c76b0375543212996cb918bbc451c48321b65ce01853254938440db0d74236ba",
-    "zh:ca7c091e9171eafafdf52d161da0786162dccd0a2b01a42e6e81ce6c59ca3333",
-    "zh:cd160ee6c9f151c6dffa151abd5a7d25f101c7d62de91a623b253972fc6997c3",
-    "zh:d4859e318f2ad0e86e7bb192183edc55bbf053939dad1540900963a325ac4818",
-    "zh:e7309aa5889362abc0617d340d019bfde9b985b5bd07d746505a9a2561ea712e",
-  ]
-  constraints = "8.17.0"
-}
-
 provider "registry.terraform.io/oracle/oci" {
   version     = "8.17.0"
   constraints = "~> 8.0"

--- a/infrastructure/terragrunt/root.hcl
+++ b/infrastructure/terragrunt/root.hcl
@@ -536,6 +536,108 @@ locals {
   }
 
   # ---------------------------------------------------------------------------
+  # JELLYFIN  (composition lives in _env_helpers/jellyfin-config.hcl)
+  # ---------------------------------------------------------------------------
+  # --- endpoint + api_key come from Vault (secret/jellyfin) via TF_VAR_*, not
+  #     here. Singleton configs default to null (unmanaged) and scheduled_tasks
+  #     to {} until the live server's settings are codified: pull the current
+  #     config from the jellyfin API, paste the settings object below, then
+  #     `terragrunt import` the singleton resource before the first apply. ---
+
+  jellyfin_encoding_configuration = {
+    EncodingThreadCount                                       = -1
+    EnableFallbackFont                                        = false
+    EnableAudioVbr                                            = false
+    DownMixAudioBoost                                         = 2
+    DownMixStereoAlgorithm                                    = "None"
+    MaxMuxingQueueSize                                        = 2048
+    EnableThrottling                                          = true
+    ThrottleDelaySeconds                                      = 180
+    EnableSegmentDeletion                                     = true
+    SegmentKeepSeconds                                        = 720
+    HardwareAccelerationType                                  = "nvenc"
+    EncoderAppPathDisplay                                     = "/usr/lib/jellyfin-ffmpeg/ffmpeg"
+    VaapiDevice                                               = "/dev/dri/renderD128"
+    QsvDevice                                                 = ""
+    EnableTonemapping                                         = false
+    EnableVppTonemapping                                      = false
+    EnableVideoToolboxTonemapping                             = false
+    TonemappingAlgorithm                                      = "bt2390"
+    TonemappingMode                                           = "auto"
+    TonemappingRange                                          = "auto"
+    TonemappingDesat                                          = 0
+    TonemappingPeak                                           = 100
+    TonemappingParam                                          = 0
+    VppTonemappingBrightness                                  = 16
+    VppTonemappingContrast                                    = 1
+    H264Crf                                                   = 23
+    H265Crf                                                   = 28
+    DeinterlaceDoubleRate                                     = false
+    DeinterlaceMethod                                         = "yadif"
+    EnableDecodingColorDepth10Hevc                            = true
+    EnableDecodingColorDepth10Vp9                             = true
+    EnableDecodingColorDepth10HevcRext                        = false
+    EnableDecodingColorDepth12HevcRext                        = false
+    EnableEnhancedNvdecDecoder                                = true
+    PreferSystemNativeHwDecoder                               = true
+    EnableIntelLowPowerH264HwEncoder                          = false
+    EnableIntelLowPowerHevcHwEncoder                          = false
+    EnableHardwareEncoding                                    = true
+    AllowHevcEncoding                                         = true
+    AllowAv1Encoding                                          = true
+    EnableSubtitleExtraction                                  = true
+    HardwareDecodingCodecs                                    = ["h264", "vc1", "hevc", "av1"]
+    AllowOnDemandMetadataBasedKeyframeExtractionForExtensions = ["mkv"]
+  }
+  jellyfin_livetv_configuration = {
+    EnableRecordingSubfolders                = false
+    EnableOriginalAudioWithEncodedRecordings = false
+    TunerHosts = [
+      {
+        Id                            = "1bdb95cd37bb4c4f879ff486cf3549d9"
+        Url                           = "http://ersatztv.service.consul:8409/iptv/channels.m3u"
+        Type                          = "m3u"
+        ImportFavoritesOnly           = false
+        AllowHWTranscoding            = false
+        AllowFmp4TranscodingContainer = false
+        AllowStreamSharing            = true
+        FallbackMaxStreamingBitrate   = 30000000
+        EnableStreamLooping           = false
+        TunerCount                    = 0
+        IgnoreDts                     = true
+        ReadAtNativeFramerate         = true
+      },
+    ]
+    ListingProviders = [
+      {
+        Id               = "2dd2e37d7d82444cbb457977c197277f"
+        Type             = "xmltv"
+        Path             = "http://ersatztv.service.consul:8409/iptv/xmltv.xml"
+        EnabledTuners    = []
+        EnableAllTuners  = true
+        NewsCategories   = ["news", "journalism", "documentary", "current affairs"]
+        SportsCategories = ["sports", "basketball", "baseball", "football"]
+        KidsCategories   = ["kids", "family", "children", "childrens", "disney"]
+        MovieCategories  = ["movie"]
+        ChannelMappings  = []
+      },
+    ]
+    PrePaddingSeconds               = 0
+    PostPaddingSeconds              = 0
+    MediaLocationsCreated           = []
+    RecordingPostProcessorArguments = "\"{path}\""
+    SaveRecordingNFO                = true
+    SaveRecordingImages             = true
+  }
+  jellyfin_system_configuration = null
+  jellyfin_scheduled_tasks = {
+    "guide-refresh" = {
+      task_id  = "bea9b218c97bbf98c5dc1303bdb9a0ca"
+      triggers = [{ Type = "IntervalTrigger", IntervalTicks = 72000000000 }]
+    }
+  }
+
+  # ---------------------------------------------------------------------------
   # REMOTE-FILES  (composition lives in _env_helpers/remote-files.hcl)
   # ---------------------------------------------------------------------------
   # --- keyed by leaf dir name (node_name). Each entry feeds the remote-files


### PR DESCRIPTION
Closes #162

Jellyfin settings were drifting from hand edits via the API. This brings them under Terraform.

## Module
New generic `jellyfin-config` module (ThePhaseless/jellyfin provider):
- Singleton config resources (encoding / livetv / system) gated on null, plus keyed `scheduled_task` triggers.
- Takes the provider's `*_json` strings verbatim; the env_helper does the `jsonencode` from `root.hcl`, so no jellyfin specifics live in the module.
- Provider endpoint + api_key sourced from Vault (`secret/jellyfin`) via `TF_VAR_*` in `munchbox-env.sh`.
- Makefile stub + plan-only tests; `make verify` green.

## Codified (zero-diff takeovers)
- Encoding/transcode settings (nvenc HW accel).
- Live TV: ErsatzTV m3u tuner + XMLTV listing provider.
- Guide-refresh scheduled task (2h interval).

Users/libraries are out of scope for now (issue notes them as later work).